### PR TITLE
Fix possible error in RootAndLeavesClassifier

### DIFF
--- a/core/src/main/java/fr/labri/gumtree/actions/RootAndLeavesClassifier.java
+++ b/core/src/main/java/fr/labri/gumtree/actions/RootAndLeavesClassifier.java
@@ -53,11 +53,11 @@ public class RootAndLeavesClassifier extends TreeClassifier {
 		srcDelTrees = fSrcDelTrees;
 		
 		Set<Tree> fSrcMvTrees = new HashSet<>();
-		for (Tree t: srcDelTrees) {
-			if (!srcDelTrees.contains(t.getParent()))
-				fSrcDelTrees.add(t);
+		for (Tree t: srcMvTrees) {
+			if (!srcMvTrees.contains(t.getParent()))
+				fSrcMvTrees.add(t);
 		}
-		srcDelTrees = fSrcDelTrees;
+		srcMvTrees = fSrcMvTrees;
 	}
 	
 }


### PR DESCRIPTION
Originally `fSrcMvTrees` was unused, the subsequent code wrote to `fsrcDelTrees` again (to no effect). 
Alternatively, if `fSrcMvTrees` should not be used, let me know and I'll remove the redundant code.

Kind regards,


Vincent