### PR TITLE
Fixed an IndexOutOfBoundsException

### DIFF
--- a/client/src/test/java/fr/labri/gumtree/client/JdtTest.java
+++ b/client/src/test/java/fr/labri/gumtree/client/JdtTest.java
@@ -1,0 +1,80 @@
+package fr.labri.gumtree.client;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import fr.labri.gumtree.actions.ActionGenerator;
+import fr.labri.gumtree.actions.model.Action;
+import fr.labri.gumtree.gen.jdt.JdtTreeGenerator;
+import fr.labri.gumtree.matchers.Matcher;
+import fr.labri.gumtree.matchers.MatcherFactories;
+import fr.labri.gumtree.tree.Tree;
+
+public class JdtTest {
+	
+	private Path file1;
+	private Path file2;
+
+	@Before
+	public void before() throws IOException {
+		file1 = Files.createTempFile("", ".java");
+		file2 = Files.createTempFile("", ".java");
+	}
+	
+	@After
+	public void after() {
+		file1.toFile().delete();
+		file2.toFile().delete();
+	}
+	
+	private List<Action> getActions(String string1, String string2)
+			throws IOException {
+		Files.write(file1, string1.getBytes(), StandardOpenOption.WRITE);
+		Files.write(file2, string2.getBytes(), StandardOpenOption.WRITE);
+		
+		return generateActions(file1, file2);
+	}
+	
+	private List<Action> generateActions(Path file1, Path file2) throws IOException {
+		JdtTreeGenerator treeGenerator = new JdtTreeGenerator();
+		Tree tree1 = treeGenerator.fromFile(file1.toAbsolutePath().toString());
+		Tree tree2 = treeGenerator.fromFile(file2.toAbsolutePath().toString());
+		
+		Matcher matcher = MatcherFactories.newMatcher(tree1, tree2);
+		matcher.match();
+		
+		ActionGenerator generator = new ActionGenerator(tree1, tree2, matcher.getMappings());
+		generator.generate();
+		return generator.getActions();
+	}
+
+	@Test
+	public void testEmptyFiles() throws IOException {
+		List<Action> actions = getActions("", "");
+		
+		assertEquals(0, actions.size());
+	}
+	
+	@Test
+	public void testOneEmptyFile() throws IOException {
+		String emptyClass = "public class A{}";
+		List<Action> actions = getActions(emptyClass, "");
+		
+		assertEquals(3, actions.size());
+	}
+	
+	@Test
+	public void testGarbagee() throws IOException {
+		List<Action> actions = getActions("bklafdfdsafduh43b", "");
+		assertEquals(0, actions.size());
+	}
+}

--- a/core/src/main/java/fr/labri/gumtree/matchers/heuristic/gt/SubtreeMatcher.java
+++ b/core/src/main/java/fr/labri/gumtree/matchers/heuristic/gt/SubtreeMatcher.java
@@ -84,7 +84,12 @@ public abstract class SubtreeMatcher extends Matcher {
 
 		@SuppressWarnings("unchecked")
 		public PriorityTreeList(Tree tree) {
-			trees = (List<Tree>[]) new ArrayList[tree.getHeight() - MIN_HEIGHT + 1];
+			int listSize = tree.getHeight() - MIN_HEIGHT + 1;
+			if (listSize < 0)
+				listSize = 0;
+			if (listSize == 0)
+				currentIdx = -1;
+			trees = (List<Tree>[]) new ArrayList[listSize];
 			maxHeight = tree.getHeight();
 			addTree(tree);
 		}


### PR DESCRIPTION
When trying to diff with an invalid java file, the Matcher would throw an IndexOutOfBoundsException. This would happen because the invalid java file would be parsed into an empty tree. Trying to match with that empty tree would cause the exception.

I added a few tests to highlight the issue. I also fixed the problem by making sure that the currentIdx field would be -1 if the tree was empty. 