### PR TITLE
Java 8 compliance

### DIFF
--- a/client/src/main/java/fr/labri/gumtree/client/StringHtmlDiff.java
+++ b/client/src/main/java/fr/labri/gumtree/client/StringHtmlDiff.java
@@ -1,0 +1,25 @@
+package fr.labri.gumtree.client;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+
+import org.rendersnake.HtmlCanvas;
+
+import fr.labri.gumtree.client.ui.web.views.DiffView;
+
+public class StringHtmlDiff {
+	
+	public static void main(String args[]) throws Exception {
+		
+		Path file1 = Files.createTempFile("", ".java");
+		Path file2 = Files.createTempFile("", ".java");
+		Files.write(file1, "public class A{public void m()}".getBytes(), StandardOpenOption.WRITE);
+		Files.write(file2, "public class B{public void m()}".getBytes(), StandardOpenOption.WRITE);
+		
+		DiffView diffView = new DiffView(file1.toFile(), file2.toFile());
+		HtmlCanvas html = new HtmlCanvas();
+		diffView.renderOn(html);
+		System.out.println(html.toHtml());
+	}
+}

--- a/client/src/main/java/fr/labri/gumtree/client/StringHtmlDiff.java
+++ b/client/src/main/java/fr/labri/gumtree/client/StringHtmlDiff.java
@@ -10,14 +10,14 @@ import fr.labri.gumtree.client.ui.web.views.DiffView;
 
 public class StringHtmlDiff {
 	
-	public String getHtmlOfDiff(String urlFolder, String aContent, String bContent) throws Exception {
+	public String getHtmlOfDiff(String urlFolder, String aContent, String bContent, String aName, String bName) throws Exception {
 		
 		Path file1 = Files.createTempFile("A", ".java");
 		Path file2 = Files.createTempFile("B", ".java");
 		Files.write(file1, aContent.getBytes(), StandardOpenOption.WRITE);
 		Files.write(file2, bContent.getBytes(), StandardOpenOption.WRITE);
 		
-		DiffView diffView = new DiffView(file1.toFile(), file2.toFile());
+		DiffView diffView = new DiffView(file1.toFile(), file2.toFile(), aName, bName);
 		diffView.setURLFolder(urlFolder);
 		HtmlCanvas html = new HtmlCanvas();
 		diffView.renderOn(html);

--- a/client/src/main/java/fr/labri/gumtree/client/StringHtmlDiff.java
+++ b/client/src/main/java/fr/labri/gumtree/client/StringHtmlDiff.java
@@ -21,6 +21,9 @@ public class StringHtmlDiff {
 		diffView.setURLFolder(urlFolder);
 		HtmlCanvas html = new HtmlCanvas();
 		diffView.renderOn(html);
+		
+		file1.toFile().delete();
+		file2.toFile().delete();
 		return html.toHtml();
 	}
 }

--- a/client/src/main/java/fr/labri/gumtree/client/StringHtmlDiff.java
+++ b/client/src/main/java/fr/labri/gumtree/client/StringHtmlDiff.java
@@ -10,16 +10,17 @@ import fr.labri.gumtree.client.ui.web.views.DiffView;
 
 public class StringHtmlDiff {
 	
-	public static void main(String args[]) throws Exception {
+	public String getHtmlOfDiff(String urlFolder, String aContent, String bContent) throws Exception {
 		
-		Path file1 = Files.createTempFile("", ".java");
-		Path file2 = Files.createTempFile("", ".java");
-		Files.write(file1, "public class A{public void m()}".getBytes(), StandardOpenOption.WRITE);
-		Files.write(file2, "public class B{public void m()}".getBytes(), StandardOpenOption.WRITE);
+		Path file1 = Files.createTempFile("A", ".java");
+		Path file2 = Files.createTempFile("B", ".java");
+		Files.write(file1, aContent.getBytes(), StandardOpenOption.WRITE);
+		Files.write(file2, bContent.getBytes(), StandardOpenOption.WRITE);
 		
 		DiffView diffView = new DiffView(file1.toFile(), file2.toFile());
+		diffView.setURLFolder(urlFolder);
 		HtmlCanvas html = new HtmlCanvas();
 		diffView.renderOn(html);
-		System.out.println(html.toHtml());
+		return html.toHtml();
 	}
 }

--- a/client/src/main/java/fr/labri/gumtree/client/ui/web/views/BootstrapHeader.java
+++ b/client/src/main/java/fr/labri/gumtree/client/ui/web/views/BootstrapHeader.java
@@ -27,7 +27,7 @@ public class BootstrapHeader implements Renderable {
 			.meta(name("viewport").content("width=device-width, initial-scale=1.0"))
 			.title().content("GumTree")
 			.macros().stylesheet("https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css")
-			.macros().stylesheet("/" + urlFolder +  "res/web/gumtree.css")
+			.macros().stylesheet("/" + urlFolder +  "/res/web/gumtree.css")
 		._head();
 	}
 

--- a/client/src/main/java/fr/labri/gumtree/client/ui/web/views/BootstrapHeader.java
+++ b/client/src/main/java/fr/labri/gumtree/client/ui/web/views/BootstrapHeader.java
@@ -8,6 +8,16 @@ import org.rendersnake.HtmlCanvas;
 import org.rendersnake.Renderable;
 
 public class BootstrapHeader implements Renderable {
+	
+	private String urlFolder;
+
+	public BootstrapHeader() {
+		this("");
+	}
+	
+	public BootstrapHeader(String urlFolder) {
+		this.urlFolder = urlFolder;
+	}
 
 	@Override
 	public void renderOn(HtmlCanvas html) throws IOException {
@@ -16,8 +26,8 @@ public class BootstrapHeader implements Renderable {
 			.meta(charset("utf8"))
 			.meta(name("viewport").content("width=device-width, initial-scale=1.0"))
 			.title().content("GumTree")
-			.macros().stylesheet("res/web/bootstrap.min.css")
-			.macros().stylesheet("res/web/gumtree.css")
+			.macros().stylesheet("https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css")
+			.macros().stylesheet("/" + urlFolder +  "res/web/gumtree.css")
 		._head();
 	}
 

--- a/client/src/main/java/fr/labri/gumtree/client/ui/web/views/DiffView.java
+++ b/client/src/main/java/fr/labri/gumtree/client/ui/web/views/DiffView.java
@@ -57,9 +57,11 @@ public class DiffView implements Renderable {
 						._div()
 					._div()
 				._div()
-				.macros().javascript("res/web/jquery.min.js")
-				.macros().javascript("res/web/bootstrap.min.js")
+				.macros().javascript("https://code.jquery.com/jquery-1.11.2.min.js")
+				.macros().javascript("https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js")
 				.macros().javascript("res/web/diff.js")
+				.macros().stylesheet("https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css")
+				.macros().stylesheet("https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap-theme.min.css")
 			._body()
 		._html();
 	}
@@ -73,10 +75,7 @@ public class DiffView implements Renderable {
 				.div(class_("btn-toolbar pull-right"))
 					.div(class_("btn-group"))
 					    .a(class_("btn btn-default btn-xs").id("legend").href("#").add("data-toggle", "popover").add("data-html", "true").add("data-placement", "bottom").add("data-content", "<span class=&quot;del&quot;>&nbsp;&nbsp;</span> deleted<br><span class=&quot;add&quot;>&nbsp;&nbsp;</span> added<br><span class=&quot;mv&quot;>&nbsp;&nbsp;</span> moved<br><span class=&quot;upd&quot;>&nbsp;&nbsp;</span> updated<br>", false).add("data-original-title", "Legend").title("Legend").role("button")).content("Legend")
-						.a(class_("btn btn-default btn-xs").id("shortcuts").href("#").add("data-toggle", "popover").add("data-html", "true").add("data-placement", "bottom").add("data-content", "<b>q</b> quit<br><b>l</b> list<br><b>n</b> next<br><b>t</b> top<br><b>b</b> bottom", false).add("data-original-title", "Shortcuts").title("Shortcuts").role("button")).content("Shortcuts")
-					._div()
-					.div(class_("btn-group"))
-						.a(class_("btn btn-default btn-xs btn-danger").href("/quit")).content("Quit")
+						.a(class_("btn btn-default btn-xs").id("shortcuts").href("#").add("data-toggle", "popover").add("data-html", "true").add("data-placement", "bottom").add("data-content", "<b>n</b> next<br><b>t</b> top<br><b>b</b> bottom", false).add("data-original-title", "Shortcuts").title("Shortcuts").role("button")).content("Shortcuts")
 					._div()
 				._div()
 			._div();

--- a/client/src/main/java/fr/labri/gumtree/client/ui/web/views/DiffView.java
+++ b/client/src/main/java/fr/labri/gumtree/client/ui/web/views/DiffView.java
@@ -23,6 +23,12 @@ public class DiffView implements Renderable {
 	private File fSrc;
 	
 	private File fDst;
+
+	private String urlFolder = "";
+	
+	public void setURLFolder(String urlFolder) {
+		this.urlFolder = urlFolder;
+	}
 	
 	public DiffView(File fSrc, File fDst) throws IOException {
 		this.fSrc = fSrc;
@@ -59,7 +65,7 @@ public class DiffView implements Renderable {
 				._div()
 				.macros().javascript("https://code.jquery.com/jquery-1.11.2.min.js")
 				.macros().javascript("https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js")
-				.macros().javascript("res/web/diff.js")
+				.macros().javascript("/" + urlFolder  + "res/web/diff.js")
 				.macros().stylesheet("https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css")
 				.macros().stylesheet("https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap-theme.min.css")
 			._body()

--- a/client/src/main/java/fr/labri/gumtree/client/ui/web/views/DiffView.java
+++ b/client/src/main/java/fr/labri/gumtree/client/ui/web/views/DiffView.java
@@ -55,7 +55,7 @@ public class DiffView implements Renderable {
 		html
 		.render(DocType.HTML5)
 		.html(lang("en"))
-			.render(new BootstrapHeader())
+			.render(new BootstrapHeader(urlFolder))
 			.body()
 				.div(class_("container-fluid"))
 					.div(class_("row"))
@@ -74,7 +74,7 @@ public class DiffView implements Renderable {
 				._div()
 				.macros().javascript("https://code.jquery.com/jquery-1.11.2.min.js")
 				.macros().javascript("https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js")
-				.macros().javascript("/" + urlFolder  + "res/web/diff.js")
+				.macros().javascript("/" + urlFolder + "/res/web/diff.js")
 				.macros().stylesheet("https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css")
 				.macros().stylesheet("https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap-theme.min.css")
 			._body()

--- a/client/src/main/java/fr/labri/gumtree/client/ui/web/views/DiffView.java
+++ b/client/src/main/java/fr/labri/gumtree/client/ui/web/views/DiffView.java
@@ -21,8 +21,10 @@ public class DiffView implements Renderable {
 	private HtmlDiffs diffs;
 	
 	private File fSrc;
+	private String srcName;
 	
 	private File fDst;
+	private String dstName;
 
 	private String urlFolder = "";
 	
@@ -31,8 +33,14 @@ public class DiffView implements Renderable {
 	}
 	
 	public DiffView(File fSrc, File fDst) throws IOException {
+		this(fSrc, fDst, fSrc.getName(), fDst.getName());
+	}
+	
+	public DiffView(File fSrc, File fDst, String srcName, String dstName) throws IOException {
 		this.fSrc = fSrc;
 		this.fDst = fDst;
+		this.srcName = srcName;
+		this.dstName = dstName;
 		Tree src = TreeGeneratorRegistry.getInstance().getTree(fSrc.getAbsolutePath());
 		Tree dst = TreeGeneratorRegistry.getInstance().getTree(fDst.getAbsolutePath());
 		Matcher matcher = MatcherFactories.newMatcher(src, dst);
@@ -40,6 +48,7 @@ public class DiffView implements Renderable {
 		diffs = new HtmlDiffs(fSrc, fDst, src, dst, matcher);
 		diffs.produce();
 	}
+	
 
 	@Override
 	public void renderOn(HtmlCanvas html) throws IOException {
@@ -54,11 +63,11 @@ public class DiffView implements Renderable {
 					._div()
 					.div(class_("row"))
 						.div(class_("col-lg-6 max-height"))
-							.h5().content(fSrc.getName())
+							.h5().content(srcName)
 							.pre(class_("pre max-height")).content(diffs.getSrcDiff(), false)
 						._div()
 						.div(class_("col-lg-6 max-height"))
-							.h5().content(fDst.getName())
+							.h5().content(dstName)
 							.pre(class_("pre max-height")).content(diffs.getDstDiff(), false)
 						._div()
 					._div()

--- a/client/src/test/java/fr/labri/gumtree/client/JdtTest.java
+++ b/client/src/test/java/fr/labri/gumtree/client/JdtTest.java
@@ -1,0 +1,80 @@
+package fr.labri.gumtree.client;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import fr.labri.gumtree.actions.ActionGenerator;
+import fr.labri.gumtree.actions.model.Action;
+import fr.labri.gumtree.gen.jdt.JdtTreeGenerator;
+import fr.labri.gumtree.matchers.Matcher;
+import fr.labri.gumtree.matchers.MatcherFactories;
+import fr.labri.gumtree.tree.Tree;
+
+public class JdtTest {
+	
+	private Path file1;
+	private Path file2;
+
+	@Before
+	public void before() throws IOException {
+		file1 = Files.createTempFile("", ".java");
+		file2 = Files.createTempFile("", ".java");
+	}
+	
+	@After
+	public void after() {
+		file1.toFile().delete();
+		file2.toFile().delete();
+	}
+	
+	private List<Action> getActions(String string1, String string2)
+			throws IOException {
+		Files.write(file1, string1.getBytes(), StandardOpenOption.WRITE);
+		Files.write(file2, string2.getBytes(), StandardOpenOption.WRITE);
+		
+		return generateActions(file1, file2);
+	}
+	
+	private List<Action> generateActions(Path file1, Path file2) throws IOException {
+		JdtTreeGenerator treeGenerator = new JdtTreeGenerator();
+		Tree tree1 = treeGenerator.fromFile(file1.toAbsolutePath().toString());
+		Tree tree2 = treeGenerator.fromFile(file2.toAbsolutePath().toString());
+		
+		Matcher matcher = MatcherFactories.newMatcher(tree1, tree2);
+		matcher.match();
+		
+		ActionGenerator generator = new ActionGenerator(tree1, tree2, matcher.getMappings());
+		generator.generate();
+		return generator.getActions();
+	}
+
+	@Test
+	public void testEmptyFiles() throws IOException {
+		List<Action> actions = getActions("", "");
+		
+		assertEquals(0, actions.size());
+	}
+	
+	@Test
+	public void testOneEmptyFile() throws IOException {
+		String emptyClass = "public class A{}";
+		List<Action> actions = getActions(emptyClass, "");
+		
+		assertEquals(3, actions.size());
+	}
+	
+	@Test
+	public void testGarbagee() throws IOException {
+		List<Action> actions = getActions("bklafdfdsafduh43b", "");
+		assertEquals(0, actions.size());
+	}
+}

--- a/core/src/main/java/fr/labri/gumtree/matchers/heuristic/gt/SubtreeMatcher.java
+++ b/core/src/main/java/fr/labri/gumtree/matchers/heuristic/gt/SubtreeMatcher.java
@@ -84,7 +84,12 @@ public abstract class SubtreeMatcher extends Matcher {
 
 		@SuppressWarnings("unchecked")
 		public PriorityTreeList(Tree tree) {
-			trees = (List<Tree>[]) new ArrayList[tree.getHeight() - MIN_HEIGHT + 1];
+			int listSize = tree.getHeight() - MIN_HEIGHT + 1;
+			if (listSize < 0)
+				listSize = 0;
+			if (listSize == 0)
+				currentIdx = -1;
+			trees = (List<Tree>[]) new ArrayList[listSize];
 			maxHeight = tree.getHeight();
 			addTree(tree);
 		}

--- a/gen.jdt/pom.xml
+++ b/gen.jdt/pom.xml
@@ -23,9 +23,19 @@
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.eclipse.jdt</groupId>
-			<artifactId>jdt</artifactId>
-			<version>3.7.1.v_B76_R37x</version>
+			<groupId>org.eclipse.tycho</groupId>
+  			<artifactId>org.eclipse.jdt.core</artifactId>
+  			<version>3.10.0.v20140604-1726</version>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.core</groupId>
+		    <artifactId>runtime</artifactId>
+		    <version>3.10.0-v20140318-2214</version>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.birt.runtime</groupId>
+    		<artifactId>org.eclipse.core.resources</artifactId>
+ 		   	<version>3.9.1.v20140825-1431</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/gen.jdt/src/main/java/fr/labri/gumtree/gen/jdt/AbstractJdtTreeGenerator.java
+++ b/gen.jdt/src/main/java/fr/labri/gumtree/gen/jdt/AbstractJdtTreeGenerator.java
@@ -13,12 +13,12 @@ public abstract class AbstractJdtTreeGenerator extends TreeGenerator {
 	
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	public Tree generate(String file) {
-		ASTParser parser = ASTParser.newParser(AST.JLS3);
+		ASTParser parser = ASTParser.newParser(AST.JLS8);
 		parser.setKind(ASTParser.K_COMPILATION_UNIT);
 		Map pOptions = JavaCore.getOptions();
-		pOptions.put(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_6);
-		pOptions.put(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, JavaCore.VERSION_1_6);
-		pOptions.put(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_6);
+		pOptions.put(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_8);
+		pOptions.put(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, JavaCore.VERSION_1_8);
+		pOptions.put(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_8);
 		parser.setCompilerOptions(pOptions);
 		Requestor req = new Requestor(createVisitor());
 		parser.createASTs(new String[] { file }, null, new String[] {}, req, null);

--- a/gen.jdt/src/test/java/gen/jdt/Java8Test.java
+++ b/gen.jdt/src/test/java/gen/jdt/Java8Test.java
@@ -1,0 +1,26 @@
+package gen.jdt;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+
+import org.junit.Test;
+
+import fr.labri.gumtree.gen.jdt.JdtTreeGenerator;
+import fr.labri.gumtree.tree.Tree;
+
+public class Java8Test {
+	
+	@Test
+	public void testJava8Syntax() throws IOException {
+		Path path = Files.createTempFile("", ".java");
+		String input = "public class A{public void m(){new ArrayList<Object>().stream().forEach(a -> {});}}";
+		Files.write(path, input.getBytes(), StandardOpenOption.WRITE);
+		Tree tree = new JdtTreeGenerator().fromFile(path.toAbsolutePath().toString());
+		assertEquals(24, tree.getSize());
+		path.toFile().delete();
+	}
+}


### PR DESCRIPTION
The JdtTreeGenerator can not parse Java 8 source files.

I also updated the POM to pull in the updated JDT dependencies. There is also a test that is a simple Java 8 syntax example. It parses correctly.