### PR TITLE
Java 8 Compliance

### DIFF
--- a/gen.jdt/pom.xml
+++ b/gen.jdt/pom.xml
@@ -23,9 +23,19 @@
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.eclipse.jdt</groupId>
-			<artifactId>jdt</artifactId>
-			<version>3.7.1.v_B76_R37x</version>
+			<groupId>org.eclipse.tycho</groupId>
+  			<artifactId>org.eclipse.jdt.core</artifactId>
+  			<version>3.10.0.v20140604-1726</version>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.core</groupId>
+		    <artifactId>runtime</artifactId>
+		    <version>3.10.0-v20140318-2214</version>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.birt.runtime</groupId>
+    		<artifactId>org.eclipse.core.resources</artifactId>
+ 		   	<version>3.9.1.v20140825-1431</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/gen.jdt/src/main/java/fr/labri/gumtree/gen/jdt/AbstractJdtTreeGenerator.java
+++ b/gen.jdt/src/main/java/fr/labri/gumtree/gen/jdt/AbstractJdtTreeGenerator.java
@@ -13,12 +13,12 @@ public abstract class AbstractJdtTreeGenerator extends TreeGenerator {
 	
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	public Tree generate(String file) {
-		ASTParser parser = ASTParser.newParser(AST.JLS3);
+		ASTParser parser = ASTParser.newParser(AST.JLS8);
 		parser.setKind(ASTParser.K_COMPILATION_UNIT);
 		Map pOptions = JavaCore.getOptions();
-		pOptions.put(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_6);
-		pOptions.put(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, JavaCore.VERSION_1_6);
-		pOptions.put(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_6);
+		pOptions.put(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_8);
+		pOptions.put(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, JavaCore.VERSION_1_8);
+		pOptions.put(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_8);
 		parser.setCompilerOptions(pOptions);
 		Requestor req = new Requestor(createVisitor());
 		parser.createASTs(new String[] { file }, null, new String[] {}, req, null);

--- a/gen.jdt/src/test/java/gen/jdt/Java8Test.java
+++ b/gen.jdt/src/test/java/gen/jdt/Java8Test.java
@@ -1,0 +1,26 @@
+package gen.jdt;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+
+import org.junit.Test;
+
+import fr.labri.gumtree.gen.jdt.JdtTreeGenerator;
+import fr.labri.gumtree.tree.Tree;
+
+public class Java8Test {
+	
+	@Test
+	public void testJava8Syntax() throws IOException {
+		Path path = Files.createTempFile("", ".java");
+		String input = "public class A{public void m(){new ArrayList<Object>().stream().forEach(a -> {});}}";
+		Files.write(path, input.getBytes(), StandardOpenOption.WRITE);
+		Tree tree = new JdtTreeGenerator().fromFile(path.toAbsolutePath().toString());
+		assertEquals(24, tree.getSize());
+		path.toFile().delete();
+	}
+}


### PR DESCRIPTION
The JdtTreeGenerator can now parse Java 8 source files.

I also updated the POM to pull in the updated JDT dependencies. There is also a test that is a simple Java 8 syntax example. It parses correctly.