### PR TITLE
Fix contact me link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Compared to classical code differencing tools, it has two important particularit
 * it works on a tree structure rather than a text structure,
 * it can detect moved or renamed elements in addition of deleted and inserted elements.
 
-We already deal with a wide range of languages: Java, C, JavaScript and Ruby. More languages are coming soon, if you want to help contact [me](www.labri.fr/perso/falleri).
+We already deal with a wide range of languages: Java, C, JavaScript and Ruby. More languages are coming soon, if you want to help contact [me](http://www.labri.fr/perso/falleri).
 
 ## Citing GumTree
 


### PR DESCRIPTION
The current link to your webpage in the github read me rendering. I explicitly added the protocol to indicate an absolute rather than relative link.