### PR TITLE
Import type labels of dst tree ctx into src tree ctx

### DIFF
--- a/client.diff/src/main/java/com/github/gumtreediff/client/diff/AbstractDiffClient.java
+++ b/client.diff/src/main/java/com/github/gumtreediff/client/diff/AbstractDiffClient.java
@@ -105,6 +105,7 @@ public abstract class AbstractDiffClient<O extends AbstractDiffClient.Options> e
                 ? matchers.getMatcher(getSrcTreeContext().getRoot(), getDstTreeContext().getRoot())
                 : matchers.getMatcher(opts.matcher, getSrcTreeContext().getRoot(), getDstTreeContext().getRoot());
         matcher.match();
+        getSrcTreeContext().importTypeLabels(getDstTreeContext());
         return matcher;
     }
 

--- a/client.diff/src/main/java/com/github/gumtreediff/client/diff/web/DiffView.java
+++ b/client.diff/src/main/java/com/github/gumtreediff/client/diff/web/DiffView.java
@@ -49,6 +49,7 @@ public class DiffView implements Renderable {
         TreeContext dst = Generators.getInstance().getTree(fDst.getAbsolutePath());
         Matcher matcher = Matchers.getInstance().getMatcher(src.getRoot(), dst.getRoot());
         matcher.match();
+        src.importTypeLabels(dst);
         diffs = new HtmlDiffs(fSrc, fDst, src, dst, matcher);
         diffs.produce();
     }

--- a/client.diff/src/main/java/com/github/gumtreediff/client/diff/web/ScriptView.java
+++ b/client.diff/src/main/java/com/github/gumtreediff/client/diff/web/ScriptView.java
@@ -60,6 +60,7 @@ public class ScriptView implements Renderable {
         dst = Generators.getInstance().getTree(fDst.getAbsolutePath());
         Matcher matcher = Matchers.getInstance().getMatcher(src.getRoot(), dst.getRoot());
         matcher.match();
+        src.importTypeLabels(dst);
         mappings = matcher.getMappings();
         ActionGenerator g = new ActionGenerator(src.getRoot(), dst.getRoot(), mappings);
         g.generate();

--- a/core/src/main/java/com/github/gumtreediff/tree/TreeContext.java
+++ b/core/src/main/java/com/github/gumtreediff/tree/TreeContext.java
@@ -73,6 +73,14 @@ public class TreeContext {
             throw new RuntimeException(String.format("Redefining type %d: '%s' with '%s'", type, typeLabel, name));
     }
 
+    public void importTypeLabels(TreeContext ctx) {
+        for (Map.Entry<Integer, String> label : ctx.typeLabels.entrySet()) {
+            if (!typeLabels.containsValue(label.getValue())) {
+                typeLabels.put(label.getKey(), label.getValue());
+            }
+        }
+    }
+
     public ITree createTree(int type, String label, String typeLabel) {
         registerTypeLabel(type, typeLabel);
         return new Tree(type, label);


### PR DESCRIPTION
Fix for non-existing type labels in source tree context, which are only present in dst tree context. This fixes the issue mentioned in #48.

This should be better done inside of a matcher (I think), but the matcher only receives a tree and not a tree context. Maybe take a closer look yourself before merging.