### PR TITLE
Prevent longer entity tooltips from being cut.

### DIFF
--- a/client.diff/src/main/resources/web/dist/gumtree.css
+++ b/client.diff/src/main/resources/web/dist/gumtree.css
@@ -91,3 +91,7 @@ div {
 	border-color: black;
 	font-family: "Inconsolata", "Consolas", "Liberation Sans Regular", "DejaVu Sans Mono", monospace;
 }
+
+.tooltip-inner {
+    max-width: none;
+}


### PR DESCRIPTION
Bootstrap's tooltip-inner css class limits the tooltip width to 200px. Having this property set to 'none' sets the width automatically and prevents text from being cut.