### PR TITLE
set min similarity to a better default

### DIFF
--- a/core/src/main/java/com/github/gumtreediff/matchers/heuristic/gt/GreedyBottomUpMatcher.java
+++ b/core/src/main/java/com/github/gumtreediff/matchers/heuristic/gt/GreedyBottomUpMatcher.java
@@ -33,7 +33,7 @@ import java.util.List;
  */
 public class GreedyBottomUpMatcher extends AbstractBottomUpMatcher {
 
-    public static double SIM_THRESHOLD = Double.parseDouble(System.getProperty("gumtree.match.bu.sim", "0.3"));
+    public static double SIM_THRESHOLD = Double.parseDouble(System.getProperty("gumtree.match.bu.sim", "0.6"));
 
     public GreedyBottomUpMatcher(ITree src, ITree dst, MappingStore store) {
         super(src, dst, store);


### PR DESCRIPTION
when optimizing new hard cases in [gumtree-spoon-ast-diff](https://github.com/SpoonLabs/gumtree-spoon-ast-diff/), I realized that the default of min similarity is far too low. A value of 0.5 and 0.6 gives much smaller and cleaner diffs.

WDYT?

(What will CI say? Travis OK, no test breaks.)