### PR TITLE
fix parsing property names from command line

### DIFF
--- a/client/src/main/java/com/github/gumtreediff/client/Run.java
+++ b/client/src/main/java/com/github/gumtreediff/client/Run.java
@@ -39,7 +39,7 @@ public class Run {
 
                         @Override
                         protected void process(String name, String[] args) {
-                            String key = args[0].startsWith("gumtree.") ? args[0] : "gumtree." + args[0];
+                            String key = args[0].startsWith("gt.") ? args[0] : "gt." + args[0];
                             System.setProperty(key, args[1]);
                         }
                     },


### PR DESCRIPTION
You have homogenized all property names in this [commit](https://github.com/GumTreeDiff/gumtree/commit/50e3987a0d8bf5abb0eb5c373275b14805125bc3). However, you forget to apply the change to the command line properties parsing code, thus all properties setting from command line can not take effect.