### PR TITLE
support setting specific charset for decoding source file or stream

### DIFF
--- a/client.diff/src/main/java/com/github/gumtreediff/client/diff/swing/MappingsPanel.java
+++ b/client.diff/src/main/java/com/github/gumtreediff/client/diff/swing/MappingsPanel.java
@@ -97,10 +97,11 @@ public class MappingsPanel extends JPanel implements TreeSelectionListener {
         add(split);
 
         try {
+            String charset = System.getProperty("gt.charset.decoding", "UTF-8");
             txtSrc.getUI().getEditorKit(txtSrc).read(Files.newBufferedReader(Paths.get(srcPath),
-                    Charset.forName("UTF-8")), txtSrc.getDocument(), 0);
+                    Charset.forName(charset)), txtSrc.getDocument(), 0);
             txtDst.getUI().getEditorKit(txtDst).read(Files.newBufferedReader(Paths.get(dstPath),
-                    Charset.forName("UTF-8")), txtDst.getDocument(), 0);
+                    Charset.forName(charset)), txtDst.getDocument(), 0);
         } catch (IOException | BadLocationException e) {
             e.printStackTrace();
         }

--- a/client.diff/src/main/java/com/github/gumtreediff/client/diff/web/HtmlDiffs.java
+++ b/client.diff/src/main/java/com/github/gumtreediff/client/diff/web/HtmlDiffs.java
@@ -125,8 +125,9 @@ public final class HtmlDiffs {
             }
         }
 
+        String charset = System.getProperty("gt.charset.decoding", "UTF-8");
         StringWriter w1 = new StringWriter();
-        BufferedReader r = Files.newBufferedReader(fSrc.toPath(), Charset.forName("UTF-8"));
+        BufferedReader r = Files.newBufferedReader(fSrc.toPath(), Charset.forName(charset));
         int cursor = 0;
 
         while (r.ready()) {
@@ -141,7 +142,7 @@ public final class HtmlDiffs {
         srcDiff = w1.toString();
 
         StringWriter w2 = new StringWriter();
-        r = Files.newBufferedReader(fDst.toPath(), Charset.forName("UTF-8"));
+        r = Files.newBufferedReader(fDst.toPath(), Charset.forName(charset));
         cursor = 0;
 
         while (r.ready()) {

--- a/core/src/main/java/com/github/gumtreediff/gen/TreeGenerator.java
+++ b/core/src/main/java/com/github/gumtreediff/gen/TreeGenerator.java
@@ -33,6 +33,8 @@ public abstract class TreeGenerator {
 
     protected abstract TreeContext generate(Reader r) throws IOException;
 
+    protected String charset = System.getProperty("gt.charset.decoding", "UTF-8");
+
     public TreeContext generateFromReader(Reader r) throws IOException {
         TreeContext ctx = generate(r);
         ctx.validate();
@@ -40,18 +42,23 @@ public abstract class TreeGenerator {
     }
 
     public TreeContext generateFromFile(String path) throws IOException {
-        return generateFromReader(Files.newBufferedReader(Paths.get(path), Charset.forName("UTF-8")));
+        return generateFromReader(Files.newBufferedReader(Paths.get(path), Charset.forName(charset)));
     }
 
     public TreeContext generateFromFile(File file) throws IOException {
-        return generateFromReader(Files.newBufferedReader(file.toPath(), Charset.forName("UTF-8")));
+        return generateFromReader(Files.newBufferedReader(file.toPath(), Charset.forName(charset)));
     }
 
     public TreeContext generateFromStream(InputStream stream) throws IOException {
-        return generateFromReader(new InputStreamReader(stream, "UTF-8"));
+        return generateFromReader(new InputStreamReader(stream, charset));
     }
 
     public TreeContext generateFromString(String content) throws IOException {
         return generateFromReader(new StringReader(content));
+    }
+
+    public TreeGenerator setCharset(String charset) {
+        this.charset = charset;
+        return this;
     }
 }


### PR DESCRIPTION
Current charset used for decoding and encoding is hard-coded 'UTF-8'. This patch enables setting the charset used to **decode source file** from system properties. Other i/o operations, such as writing temporary file and reading output of external tools, still use hard-coded 'UTF-8' as the default charset. 

Please review this patch.

BTW, the charset of source files can be changed in some revisions, actually. It will be better to support setting source file charset and destination file charset separately. However, it is not trivial to achieve. Because only the client knows which charset should be used for decoding in this situation, some core APIs, including `Generators.getTree(String file)` and `Generators.getTree(String generator, String file)`, and the caller of them may be required modification.