### PR TITLE
Missing Import label and modifier in gen.jdt #100

### DIFF
--- a/gen.jdt/src/main/java/com/github/gumtreediff/gen/jdt/AbstractJdtVisitor.java
+++ b/gen.jdt/src/main/java/com/github/gumtreediff/gen/jdt/AbstractJdtVisitor.java
@@ -54,9 +54,13 @@ public abstract class AbstractJdtVisitor extends ASTVisitor {
     }
 
     protected void pushFakeNode(EntityType n, int startPosition, int length) {
+        pushFakeNode(n, "", startPosition, length);
+    }
+
+    protected void pushFakeNode(EntityType n, String label, int startPosition, int length) {
         int type = -n.ordinal(); // Fake types have negative types (but does it matter ?)
-        String typeName = n.name();
-        push(type, typeName, "", startPosition, length);
+        String typeName = n.getJdtCompliantName();
+        push(type, typeName, label, startPosition, length);
     }
 
     private void push(int type, String typeName, String label, int startPosition, int length) {

--- a/gen.jdt/src/main/java/com/github/gumtreediff/gen/jdt/JdtVisitor.java
+++ b/gen.jdt/src/main/java/com/github/gumtreediff/gen/jdt/JdtVisitor.java
@@ -22,6 +22,7 @@
 package com.github.gumtreediff.gen.jdt;
 
 
+import com.github.gumtreediff.gen.jdt.cd.EntityType;
 import org.eclipse.jdt.core.dom.*;
 
 public class JdtVisitor  extends AbstractJdtVisitor {
@@ -32,6 +33,17 @@ public class JdtVisitor  extends AbstractJdtVisitor {
     @Override
     public void preVisit(ASTNode n) {
         pushNode(n, getLabel(n));
+    }
+
+    @Override
+    public boolean visit(ImportDeclaration node) {
+        if (node.isStatic()) {
+            final String statik = "static";
+            int startPosition = node.toString().indexOf(statik);
+            pushFakeNode(EntityType.MODIFIER, statik, startPosition, statik.length());
+            popNode();
+        }
+        return super.visit(node);
     }
 
     protected String getLabel(ASTNode n) {
@@ -48,7 +60,8 @@ public class JdtVisitor  extends AbstractJdtVisitor {
         if (n instanceof Assignment) return ((Assignment) n).getOperator().toString();
         if (n instanceof TextElement) return n.toString();
         if (n instanceof TagElement) return ((TagElement) n).getTagName();
-        if (n instanceof TypeDeclaration) return ((TypeDeclaration) n).isInterface()?"interface":"class";
+        if (n instanceof TypeDeclaration) return ((TypeDeclaration) n).isInterface() ? "interface" : "class";
+        if (n instanceof ImportDeclaration) return ((ImportDeclaration) n).isOnDemand() ? "on-demand" : "single-type";
 
         return "";
     }

--- a/gen.jdt/src/main/java/com/github/gumtreediff/gen/jdt/cd/EntityType.java
+++ b/gen.jdt/src/main/java/com/github/gumtreediff/gen/jdt/cd/EntityType.java
@@ -212,4 +212,15 @@ public enum EntityType {
                 return false;
         }
     }
+
+
+    public String getJdtCompliantName() {
+        StringBuilder compliantName = new StringBuilder();
+        String []part = name().split("_");
+        for (int i = 0; i < part.length; i++) {
+            compliantName.append(part[0].substring(0, 1).toUpperCase())
+                         .append(part[0].substring(1).toLowerCase());
+        }
+        return compliantName.toString();
+    }
 }

--- a/gen.jdt/src/main/java/com/github/gumtreediff/gen/jdt/cd/EntityType.java
+++ b/gen.jdt/src/main/java/com/github/gumtreediff/gen/jdt/cd/EntityType.java
@@ -218,8 +218,8 @@ public enum EntityType {
         StringBuilder compliantName = new StringBuilder();
         String []part = name().split("_");
         for (int i = 0; i < part.length; i++) {
-            compliantName.append(part[0].substring(0, 1).toUpperCase())
-                         .append(part[0].substring(1).toLowerCase());
+            compliantName.append(part[i].substring(0, 1).toUpperCase())
+                         .append(part[i].substring(1).toLowerCase());
         }
         return compliantName.toString();
     }

--- a/gen.jdt/src/test/java/com/github/gumtreediff/gen/jdt/TestIssue100.java
+++ b/gen.jdt/src/test/java/com/github/gumtreediff/gen/jdt/TestIssue100.java
@@ -1,0 +1,74 @@
+/*
+ * This file is part of GumTree.
+ *
+ * GumTree is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * GumTree is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with GumTree.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright 2011-2015 Jean-Rémy Falleri <jr.falleri@gmail.com>
+ * Copyright 2011-2015 Floréal Morandat <florealm@gmail.com>
+ */
+
+package com.github.gumtreediff.gen.jdt;
+
+import com.github.gumtreediff.actions.ActionGenerator;
+import com.github.gumtreediff.actions.model.Action;
+import com.github.gumtreediff.actions.model.Update;
+import com.github.gumtreediff.matchers.Matcher;
+import com.github.gumtreediff.matchers.Matchers;
+import com.github.gumtreediff.tree.ITree;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class TestIssue100 {
+
+    @Test
+    public void shouldHaveAModifierNode() throws IOException {
+        String left = "import com.github.gumtreediff.gen.jdt";
+        String right = "import static com.github.gumtreediff.gen.jdt";
+
+        ITree leftTree = new JdtTreeGenerator().generateFromString(left).getRoot();
+        ITree rightTree = new JdtTreeGenerator().generateFromString(right).getRoot();
+        Matcher m = Matchers.getInstance().getMatcher(leftTree, rightTree);
+        m.match();
+
+        ActionGenerator g = new ActionGenerator(leftTree, rightTree, m.getMappings());
+        List<Action> actions = g.generate();
+
+        assertEquals(1, actions.size());
+        assertEquals("INS", actions.get(0).getName());
+        assertEquals("static", actions.get(0).getNode().getLabel());
+    }
+
+    @Test
+    public void shouldBeDifferentKindOfImport() throws IOException {
+        String left = "import com.github.gumtreediff.gen.jdt";
+        String right = "import com.github.gumtreediff.gen.jdt.*";
+
+        ITree leftTree = new JdtTreeGenerator().generateFromString(left).getRoot();
+        ITree rightTree = new JdtTreeGenerator().generateFromString(right).getRoot();
+        Matcher m = Matchers.getInstance().getMatcher(leftTree, rightTree);
+        m.match();
+
+        ActionGenerator g = new ActionGenerator(leftTree, rightTree, m.getMappings());
+        List<Action> actions = g.generate();
+
+        assertEquals(1, actions.size());
+        assertEquals("on-demand", ((Update) actions.get(0)).getValue());
+        assertEquals("single-type", ((Update) actions.get(0)).getNode().getLabel());
+    }
+
+}

--- a/gen.jdt/src/test/java/com/github/gumtreediff/gen/jdt/TestIssue100.java
+++ b/gen.jdt/src/test/java/com/github/gumtreediff/gen/jdt/TestIssue100.java
@@ -37,8 +37,8 @@ public class TestIssue100 {
 
     @Test
     public void shouldHaveAModifierNode() throws IOException {
-        String left = "import com.github.gumtreediff.gen.jdt";
-        String right = "import static com.github.gumtreediff.gen.jdt";
+        String left = "import com.github.gumtreediff.gen.jdt;";
+        String right = "import static com.github.gumtreediff.gen.jdt;";
 
         ITree leftTree = new JdtTreeGenerator().generateFromString(left).getRoot();
         ITree rightTree = new JdtTreeGenerator().generateFromString(right).getRoot();
@@ -55,8 +55,8 @@ public class TestIssue100 {
 
     @Test
     public void shouldBeDifferentKindOfImport() throws IOException {
-        String left = "import com.github.gumtreediff.gen.jdt";
-        String right = "import com.github.gumtreediff.gen.jdt.*";
+        String left = "import com.github.gumtreediff.gen.jdt;";
+        String right = "import com.github.gumtreediff.gen.jdt.*;";
 
         ITree leftTree = new JdtTreeGenerator().generateFromString(left).getRoot();
         ITree rightTree = new JdtTreeGenerator().generateFromString(right).getRoot();

--- a/gen.jdt/src/test/java/com/github/gumtreediff/gen/jdt/cd/EntityTypeTest.java
+++ b/gen.jdt/src/test/java/com/github/gumtreediff/gen/jdt/cd/EntityTypeTest.java
@@ -1,0 +1,37 @@
+/*
+ * This file is part of GumTree.
+ *
+ * GumTree is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * GumTree is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with GumTree.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright 2011-2015 Jean-Rémy Falleri <jr.falleri@gmail.com>
+ * Copyright 2011-2015 Floréal Morandat <florealm@gmail.com>
+ */
+
+package com.github.gumtreediff.gen.jdt.cd;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class EntityTypeTest {
+
+    @Test
+    public void shouldHaveJdtCompliantName() {
+        assertEquals("AnnotationTypeDeclaration", EntityType.ANNOTATION_TYPE_DECLARATION.getJdtCompliantName());
+        assertEquals("DoStatement", EntityType.DO_STATEMENT.getJdtCompliantName());
+        assertEquals("VariableDeclarationExpression", EntityType.VARIABLE_DECLARATION_EXPRESSION.getJdtCompliantName());
+        assertEquals("ImportDeclaration", EntityType.IMPORT_DECLARATION.getJdtCompliantName());
+    }
+
+}


### PR DESCRIPTION
Hi,
I recently found an other issue in the JDT generator.

The three files below are considered equivalent, but they aren't.

Import.java : 

```java
     import com.github.gumtreediff.gen.jdt;
```

ImportOnDemand.java : 

```java
     import com.github.gumtreediff.gen.jdt.*;
```

StaticImport.java : 

```java
     import com.github.gumtreediff.gen.jdt.*;
```

It is possible to observe this issue with the code below : 

```java
        File left = new File("src/main/resources/Import.java");
        File right = new File("src/main/resources/ImportOnDemand.java");

        TreeContext leftTree = new JdtTreeGenerator().generateFromFile(left);
        TreeContext rightTree = new JdtTreeGenerator().generateFromFile(right);
        Matcher m = Matchers.getInstance().getMatcher(leftTree.getRoot(), rightTree.getRoot());
        m.match();

        ActionGenerator g = new ActionGenerator(leftTree.getRoot(), rightTree.getRoot(), m.getMappings());
        List<Action> actions = g.generate();

        System.out.println("actions.size() : " + actions.size());
```

```
actions.size() : 0
```

Thanks!