### PR TITLE
ON WRONG BRANCH - ignore me: support clone of custom Tree

### DIFF
--- a/core/src/main/java/com/github/gumtreediff/tree/Tree.java
+++ b/core/src/main/java/com/github/gumtreediff/tree/Tree.java
@@ -57,7 +57,7 @@ public class Tree extends AbstractTree implements ITree {
     }
 
     // Only used for cloning ...
-    private Tree(Tree other) {
+    protected Tree(Tree other) {
         this.type = other.type;
         this.label = other.getLabel();
         this.id = other.getId();


### PR DESCRIPTION
Hi!

I would like to have own implementation of `com.github.gumtreediff.tree.Tree`. It was no problem to extend Tree and create it using my own TreeContext. Super!

But it is not possible to deepCopy MyTree, because constructor is private.

Thank you
Pavel