### PR TITLE
Simplify the getParents method

### DIFF
--- a/core/src/main/java/com/github/gumtreediff/tree/ITree.java
+++ b/core/src/main/java/com/github/gumtreediff/tree/ITree.java
@@ -160,9 +160,7 @@ public interface ITree {
      */
     default List<ITree> getParents() {
         List<ITree> parents = new ArrayList<>();
-        if (getParent() == null)
-            return parents;
-        else {
+        if (getParent() != null) {
             parents.add(getParent());
             parents.addAll(getParent().getParents());
         }


### PR DESCRIPTION
[REFACTOR] The getParents method has returned parents twice, which can be simplified by changing the predicate of the if statement.