### PR TITLE
[bugfix] the Composite Matcher retrieves the options from its submatc…

### DIFF
--- a/core/src/main/java/com/github/gumtreediff/matchers/CompositeMatchers.java
+++ b/core/src/main/java/com/github/gumtreediff/matchers/CompositeMatchers.java
@@ -21,7 +21,9 @@
 package com.github.gumtreediff.matchers;
 
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import com.github.gumtreediff.gen.Registry;
 import com.github.gumtreediff.matchers.heuristic.XyBottomUpMatcher;
@@ -41,6 +43,7 @@ import com.github.gumtreediff.matchers.optimizations.LcsOptMatcherThetaB;
 import com.github.gumtreediff.matchers.optimizations.LeafMoveMatcherThetaE;
 import com.github.gumtreediff.matchers.optimizations.UnmappedLeavesMatcherThetaC;
 import com.github.gumtreediff.tree.ITree;
+import com.google.common.collect.Sets;
 
 public class CompositeMatchers {
     public static class CompositeMatcher implements ConfigurableMatcher {
@@ -70,6 +73,20 @@ public class CompositeMatchers {
         public List<Matcher> matchers() {
             return Arrays.asList(matchers);
         }
+
+        @Override
+        public Set<ConfigurationOptions> getApplicableOptions() {
+            Set<ConfigurationOptions> allOptions = Sets.newHashSet();
+            for (Matcher matcher : matchers) {
+                if (matcher instanceof Configurable) {
+                    allOptions.addAll(((Configurable) matcher).getApplicableOptions());
+                }
+
+            }
+
+            return allOptions;
+        }
+
     }
 
     @Register(id = "gumtree", defaultMatcher = true, priority = Registry.Priority.HIGH)

--- a/core/src/test/java/com/github/gumtreediff/test/TestGumTreeProperties.java
+++ b/core/src/test/java/com/github/gumtreediff/test/TestGumTreeProperties.java
@@ -22,6 +22,7 @@ package com.github.gumtreediff.test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -251,6 +252,21 @@ class TestGumTreeProperties {
 
         assertEquals(newSizeThrvalue, opGreedyBottomUp.get().getSize_threshold());
         assertEquals(originalSimThr, opGreedyBottomUp.get().getSim_threshold());
+
+        assertNotNull(composite.getApplicableOptions());
+        assertFalse(composite.getApplicableOptions().isEmpty());
+
+        int optionsFromGreedySubMatcher = opGreedySubTree.get().getApplicableOptions().size();
+        assertEquals(1, optionsFromGreedySubMatcher);
+
+        int optionsFromGreedyBottomUpMatcher = opGreedyBottomUp.get().getApplicableOptions().size();
+        assertEquals(2, optionsFromGreedyBottomUpMatcher);
+
+        assertEquals((optionsFromGreedySubMatcher + optionsFromGreedyBottomUpMatcher),
+                composite.getApplicableOptions().size());
+
+        assertTrue(composite.getApplicableOptions().containsAll(opGreedySubTree.get().getApplicableOptions()));
+        assertTrue(composite.getApplicableOptions().containsAll(opGreedyBottomUp.get().getApplicableOptions()));
 
     }
 


### PR DESCRIPTION
…hers

In the previous version, the composite matcher always returned an empty set of options.
Now, it collects those from its sub-matchers.