### PR TITLE
Fix to align children logic

### DIFF
--- a/core/src/main/java/com/github/gumtreediff/actions/ChawatheScriptGenerator.java
+++ b/core/src/main/java/com/github/gumtreediff/actions/ChawatheScriptGenerator.java
@@ -162,18 +162,15 @@ public class ChawatheScriptGenerator implements EditScriptGenerator {
             dstInOrder.add(m.second);
         }
 
-        for (ITree a : s1) {
-            for (ITree b: s2 ) {
-                if (origMappings.has(a, b)) {
+        for (ITree b: s2 ) { // iterate through s2 first, to ensure left-to-right insertions
+            for (ITree a : s1) {
+                if (cpyMappings.has(a, b)) {
                     if (!lcs.contains(new Mapping(a, b))) {
-                        int k = findPos(b);
+                        a.getParent().getChildren().remove(a); // remove this node directly.
+                        int k = findPos(b); // find insert position AFTER removing node from old place.
                         Action mv = new Move(copyToOrig.get(a), copyToOrig.get(w), k);
                         actions.add(mv);
-                        int oldk = a.positionInParent();
                         w.getChildren().add(k, a);
-                        if (k  < oldk ) // FIXME this is an ugly way to patch the index
-                            oldk ++;
-                        a.getParent().getChildren().remove(oldk);
                         a.setParent(w);
                         srcInOrder.add(a);
                         dstInOrder.add(b);

--- a/core/src/test/java/com/github/gumtreediff/test/TestActionGenerator.java
+++ b/core/src/test/java/com/github/gumtreediff/test/TestActionGenerator.java
@@ -191,4 +191,36 @@ public class TestActionGenerator {
                 new Insert(dst.getChild("0.1.1"), src.getChild(1), 1)
         ));
     }
+
+    @Test
+    void testAlignChildren() {
+        ITree t1 = new Tree(TypeSet.type("root"));
+        ITree a1 = new Tree(TypeSet.type("a"));
+        t1.addChild(a1);
+        ITree b1 = new Tree(TypeSet.type("b"));
+        t1.addChild(b1);
+        System.out.println(t1.toTreeString());
+        // root [0,0]
+        //     a [0,0]
+        //     b [0,0]
+
+        ITree t2 = new Tree(TypeSet.type("root"));
+        ITree b2 = new Tree(TypeSet.type("b"));
+        t2.addChild(b2);
+        ITree a2 = new Tree(TypeSet.type("a"));
+        t2.addChild(a2);
+        System.out.println(t2.toTreeString());
+        // root [0,0]
+        //     b [0,0]
+        //     a [0,0]
+
+        MappingStore mp = new MappingStore(t1, t2);
+        mp.addMapping(t1, t2);
+        mp.addMapping(a1, a2);
+        mp.addMapping(b1, b2);
+
+        EditScript actions =  new ChawatheScriptGenerator().computeActions(mp);
+
+        assertEquals(1, actions.size());
+    }
 }


### PR DESCRIPTION
In trying to use this library, I found that the edit scripts generated did **not** always produce the correct output when actually applied to the original tree. I traced the problem to the alignment logic - the indices being accessed when deciding how to align the trees were not always correct.

This pull request fixes these issues and includes a minimal unit test which fails without the fix. 