### PR TITLE
feat: add command to dump vanilla diff output

### DIFF
--- a/client.diff/src/main/java/com/github/gumtreediff/client/diff/HtmlDiff.java
+++ b/client.diff/src/main/java/com/github/gumtreediff/client/diff/HtmlDiff.java
@@ -31,21 +31,38 @@ import org.rendersnake.Renderable;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.FileWriter;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
 @Register(name = "htmldiff", description = "Dump diff as HTML in stdout",
-        options = AbstractDiffClient.DiffOptions.class)
-public class HtmlDiff extends AbstractDiffClient<AbstractDiffClient.DiffOptions> {
+        options = HtmlDiff.HtmlDiffOptions.class)
+public class HtmlDiff extends AbstractDiffClient<HtmlDiff.HtmlDiffOptions> {
 
     public HtmlDiff(String[] args) {
         super(args);
     }
 
+    public static class HtmlDiffOptions extends AbstractDiffClient.DiffOptions {
+        protected String output;
+
+        @Override
+        public Option[] values() {
+            return Option.Context.addValue(super.values(),
+                    new Option("-o", "output file", 1) {
+                        @Override
+                        protected void process(String name, String[] args) {
+                            output = args[0];
+                        }
+                    }
+            );
+        }
+    }
+
     @Override
-    protected DiffOptions newOptions() {
-        return new DiffOptions();
+    protected HtmlDiffOptions newOptions() {
+        return new HtmlDiffOptions();
     }
 
     @Override
@@ -56,6 +73,14 @@ public class HtmlDiff extends AbstractDiffClient<AbstractDiffClient.DiffOptions>
         Renderable view = new VanillaDiffView(pair.first, pair.second, diff, true);
         HtmlCanvas c = new HtmlCanvas();
         view.renderOn(c);
-        System.out.println(c.toHtml());
+        if (opts.output == null) {
+            System.out.println(c.toHtml());
+        }
+        else {
+            File htmlOutput = new File(opts.output);
+            FileWriter writer = new FileWriter(htmlOutput);
+            writer.write(c.toHtml());
+            writer.close();
+        }
     }
 }

--- a/client.diff/src/main/java/com/github/gumtreediff/client/diff/HtmlDiff.java
+++ b/client.diff/src/main/java/com/github/gumtreediff/client/diff/HtmlDiff.java
@@ -1,0 +1,61 @@
+/*
+ * This file is part of GumTree.
+ *
+ * GumTree is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * GumTree is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with GumTree.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright 2017 Jean-Rémy Falleri <jr.falleri@gmail.com>
+ */
+
+package com.github.gumtreediff.client.diff;
+
+import com.github.gumtreediff.io.DirectoryComparator;
+import com.github.gumtreediff.client.Register;
+import com.github.gumtreediff.actions.Diff;
+import com.github.gumtreediff.utils.Pair;
+import com.github.gumtreediff.client.Option;
+import com.github.gumtreediff.client.diff.webdiff.VanillaDiffView;
+
+import org.rendersnake.HtmlCanvas;
+import org.rendersnake.Renderable;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+@Register(name = "htmldiff", description = "Dump diff as HTML in stdout",
+        options = AbstractDiffClient.DiffOptions.class)
+public class HtmlDiff extends AbstractDiffClient<AbstractDiffClient.DiffOptions> {
+
+    public HtmlDiff(String[] args) {
+        super(args);
+    }
+
+    @Override
+    protected DiffOptions newOptions() {
+        return new DiffOptions();
+    }
+
+    @Override
+    public void run() throws IOException {
+        DirectoryComparator comparator = new DirectoryComparator(opts.srcPath, opts.dstPath);
+        Pair<File, File> pair = comparator.getModifiedFiles().get(0);
+        Diff diff = getDiff(pair.first.getAbsolutePath(), pair.second.getAbsolutePath());
+        Renderable view = new VanillaDiffView(pair.first, pair.second, diff, true);
+        HtmlCanvas c = new HtmlCanvas();
+        view.renderOn(c);
+        System.out.println(c.toHtml());
+    }
+}

--- a/client.diff/src/main/java/com/github/gumtreediff/client/diff/webdiff/VanillaDiffView.java
+++ b/client.diff/src/main/java/com/github/gumtreediff/client/diff/webdiff/VanillaDiffView.java
@@ -27,6 +27,9 @@ import org.rendersnake.Renderable;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.charset.Charset;
 
 import static org.rendersnake.HtmlAttributesFactory.*;
 
@@ -38,10 +41,13 @@ public class VanillaDiffView implements Renderable {
 
     private Diff diff;
 
-    public VanillaDiffView(File srcFile, File dstFile, Diff diff) throws IOException {
+    private boolean dump;
+
+    public VanillaDiffView(File srcFile, File dstFile, Diff diff, boolean dump) throws IOException {
         this.srcFile = srcFile;
         this.dstFile = dstFile;
         this.diff = diff;
+        this.dump = dump;
         rawHtmlDiff = new VanillaDiffHtmlBuilder(srcFile, dstFile, diff);
         rawHtmlDiff.produce();
     }
@@ -51,7 +57,7 @@ public class VanillaDiffView implements Renderable {
         html
         .render(DocType.HTML5)
         .html(lang("en"))
-            .render(new Header())
+            .render(new Header(dump))
             .body()
                 .div(class_("container-fluid"))
                     .div(class_("row"))
@@ -103,21 +109,53 @@ public class VanillaDiffView implements Renderable {
     }
 
     private static class Header implements Renderable {
+
+        private boolean dump;
+
+        public Header(boolean dump) throws IOException {
+            this.dump = dump;
+        }
+
         @Override
         public void renderOn(HtmlCanvas html) throws IOException {
-             html
-                     .head()
-                        .meta(charset("utf8"))
-                        .meta(name("viewport").content("width=device-width, initial-scale=1.0"))
-                        .title().content("GumTree")
-                        .macros().stylesheet(WebDiff.BOOTSTRAP_CSS_URL)
-                        .macros().stylesheet("/dist/vanilla.css")
-                        .macros().javascript(WebDiff.JQUERY_JS_URL)
-                        .macros().javascript(WebDiff.POPPER_JS_URL)
-                        .macros().javascript(WebDiff.BOOTSTRAP_JS_URL)
-                        .macros().javascript("/dist/shortcuts.js")
-                        .macros().javascript("/dist/vanilla.js")
-                     ._head();
+            if (!dump) {
+                html
+                        .head()
+                           .meta(charset("utf8"))
+                           .meta(name("viewport").content("width=device-width, initial-scale=1.0"))
+                           .title().content("GumTree")
+                           .macros().stylesheet(WebDiff.BOOTSTRAP_CSS_URL)
+                           .macros().stylesheet("/dist/vanilla.css")
+                           .macros().javascript(WebDiff.JQUERY_JS_URL)
+                           .macros().javascript(WebDiff.POPPER_JS_URL)
+                           .macros().javascript(WebDiff.BOOTSTRAP_JS_URL)
+                           .macros().javascript("/dist/shortcuts.js")
+                           .macros().javascript("/dist/vanilla.js")
+                        ._head();
+            }
+            else {
+                html
+                        .head()
+                           .meta(charset("utf8"))
+                           .meta(name("viewport").content("width=device-width, initial-scale=1.0"))
+                           .title().content("GumTree")
+                           .macros().stylesheet(WebDiff.BOOTSTRAP_CSS_URL)
+                           .style(type("text/css"))
+                           .write(readFile("/home/poski/Desktop/gumtree/client.diff/src/main/resources/web/dist/vanilla.css"))
+                           ._style()
+                           .macros().javascript(WebDiff.JQUERY_JS_URL)
+                           .macros().javascript(WebDiff.POPPER_JS_URL)
+                           .macros().javascript(WebDiff.BOOTSTRAP_JS_URL)
+                           .macros().script(readFile("/home/poski/Desktop/gumtree/client.diff/src/main/resources/web/dist/shortcuts.js"))
+                           .macros().script(readFile("/home/poski/Desktop/gumtree/client.diff/src/main/resources/web/dist/vanilla.js"))
+                        ._head();
+            }
+        }
+
+        private static String readFile(String path)  throws IOException {
+            byte[] encoded = Files.readAllBytes(Paths.get(path));
+            Charset encoding = Charset.defaultCharset();
+            return new String(encoded, encoding);
         }
     }
 }

--- a/client.diff/src/main/java/com/github/gumtreediff/client/diff/webdiff/VanillaDiffView.java
+++ b/client.diff/src/main/java/com/github/gumtreediff/client/diff/webdiff/VanillaDiffView.java
@@ -26,6 +26,9 @@ import org.rendersnake.HtmlCanvas;
 import org.rendersnake.Renderable;
 
 import java.io.File;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.BufferedReader;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -141,21 +144,27 @@ public class VanillaDiffView implements Renderable {
                            .title().content("GumTree")
                            .macros().stylesheet(WebDiff.BOOTSTRAP_CSS_URL)
                            .style(type("text/css"))
-                           .write(readFile("/home/poski/Desktop/gumtree/client.diff/src/main/resources/web/dist/vanilla.css"))
+                           .write(readFile("web/dist/vanilla.css"))
                            ._style()
                            .macros().javascript(WebDiff.JQUERY_JS_URL)
                            .macros().javascript(WebDiff.POPPER_JS_URL)
                            .macros().javascript(WebDiff.BOOTSTRAP_JS_URL)
-                           .macros().script(readFile("/home/poski/Desktop/gumtree/client.diff/src/main/resources/web/dist/shortcuts.js"))
-                           .macros().script(readFile("/home/poski/Desktop/gumtree/client.diff/src/main/resources/web/dist/vanilla.js"))
+                           .macros().script(readFile("web/dist/shortcuts.js"))
+                           .macros().script(readFile("web/dist/vanilla.js"))
                         ._head();
             }
         }
 
-        private static String readFile(String path)  throws IOException {
-            byte[] encoded = Files.readAllBytes(Paths.get(path));
-            Charset encoding = Charset.defaultCharset();
-            return new String(encoded, encoding);
+        private static String readFile(String resourceName)  throws IOException {
+            ClassLoader classloader = Thread.currentThread().getContextClassLoader();
+            InputStream inputStream = classloader.getResourceAsStream(resourceName);
+            InputStreamReader streamReader = new InputStreamReader(inputStream, Charset.defaultCharset());
+            BufferedReader reader = new BufferedReader(streamReader);
+            String content = "";
+            for (String line; (line = reader.readLine()) != null;) {
+                content += line + "\n";
+            }
+            return content;
         }
     }
 }

--- a/client.diff/src/main/java/com/github/gumtreediff/client/diff/webdiff/WebDiff.java
+++ b/client.diff/src/main/java/com/github/gumtreediff/client/diff/webdiff/WebDiff.java
@@ -103,7 +103,7 @@ public class WebDiff extends AbstractDiffClient<WebDiff.WebDiffOptions> {
             int id = Integer.parseInt(request.params(":id"));
             Pair<File, File> pair = comparator.getModifiedFiles().get(id);
             Diff diff = getDiff(pair.first.getAbsolutePath(), pair.second.getAbsolutePath());
-            Renderable view = new VanillaDiffView(pair.first, pair.second, diff);
+            Renderable view = new VanillaDiffView(pair.first, pair.second, diff, false);
             return render(view);
         });
         get("/monaco-diff/:id", (request, response) -> {


### PR DESCRIPTION
These changes add a command called `htmldiff` which dumps HTML output of vanilla-diff in `stdout`. The dependent CSS and JS are read and then dumped directly into this output. However, two changes must be done before it is ready for merge:
- [x] Make the file path [here](https://github.com/GumTreeDiff/gumtree/compare/develop...algomaster99:htmldiff?expand=1#diff-c44792f1885cb1fdb6cedddb6e14af31c3ce5e027ed465870915aa62735a84e7R149) relative.
- [x] The output doesn't pop this menu when "Legends" is clicked
![Screenshot from 2020-11-29 13-31-20](https://user-images.githubusercontent.com/35191225/100537505-34870080-324f-11eb-808d-7662b5cf45c9.png)
