### PR TITLE
fix: add runtime dependency from client to client.diff to display complete available commands with Run.java.

### DIFF
--- a/client/build.gradle
+++ b/client/build.gradle
@@ -1,1 +1,5 @@
 description = 'GumTree abstract client module.'
+
+dependencies {
+    runtime project(':client.diff')
+}


### PR DESCRIPTION
Remember that there are 2 issues (https://github.com/GumTreeDiff/gumtree/issues/88 https://github.com/GumTreeDiff/gumtree/issues/69) about running main() in Run.java failing to display all available commands?

It was previously solved by a workaround: build the distribution, unzip to get all jars and add folder `lib` as the Runtime dependency of `client_main` module.

However, this is neither elegant nor saved, resyncing gradle requires doing this again. And the latest source code cannot be debugged without a fresh building, for different IDE it requires different settings. 

So I tried to add this to `client/build.gradle`:

```grovvy
dependencies {
      runtime fileTree(dir: '/Users/symbolk/coding/code_analysis/gumtree/dist/build/install/gumtree/lib', include: ['*.jar'])
}
```
It worked fine, so a step further:

```grovvy
dependencies {
    runtime project(':client.diff')
}
```

It also worked fine for me, so I think I found a simple solution, please verify this.
