### PR TITLE
Replaced dependency on trove4j for equivalent dependency on fastutil

### DIFF
--- a/client.diff/build.gradle
+++ b/client.diff/build.gradle
@@ -4,7 +4,7 @@ dependencies {
 	implementation project(':client')
 	implementation 'com.sparkjava:spark-core:2.9.1'
 	implementation 'org.slf4j:slf4j-simple:1.7.21'
-	implementation 'net.sf.trove4j:trove4j:3.0.3'
+	implementation 'it.unimi.dsi:fastutil:8.3.1'
 	// exclude servlet-api 2.0 because it causes a bug with spark-core
 	implementation('org.rendersnake:rendersnake:1.9.0') {
 		exclude group: 'javax.servlet', module: 'servlet-api'

--- a/client.diff/src/main/java/com/github/gumtreediff/client/diff/webdiff/VanillaDiffHtmlBuilder.java
+++ b/client.diff/src/main/java/com/github/gumtreediff/client/diff/webdiff/VanillaDiffHtmlBuilder.java
@@ -25,8 +25,8 @@ import com.github.gumtreediff.actions.TreeClassifier;
 import com.github.gumtreediff.utils.SequenceAlgorithms;
 import com.github.gumtreediff.tree.Tree;
 import com.github.gumtreediff.tree.TreeContext;
-import gnu.trove.map.TObjectIntMap;
-import gnu.trove.map.hash.TObjectIntHashMap;
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 
 import java.io.*;
 import java.nio.charset.Charset;
@@ -63,7 +63,7 @@ public final class VanillaDiffHtmlBuilder {
 
     public void produce() throws IOException {
         TreeClassifier c = diff.createRootNodesClassifier();
-        TObjectIntMap<Tree> mappingIds = new TObjectIntHashMap<>();
+        Object2IntMap<Tree> mappingIds = new Object2IntOpenHashMap<>();
 
         int uId = 1;
         int mId = 1;
@@ -96,13 +96,13 @@ public final class VanillaDiffHtmlBuilder {
         TagIndex rtags = new TagIndex();
         for (Tree t: diff.dst.getRoot().preOrder()) {
             if (c.getMovedDsts().contains(t)) {
-                int dId = mappingIds.get(t);
+                int dId = mappingIds.getInt(t);
                 rtags.addStartTag(t.getPos(), String.format(ID_SPAN, uId++));
                 rtags.addTags(t.getPos(), String.format(
                                 DST_MV_SPAN, "token mv", dId, tooltip(diff.dst, t)), t.getEndPos(), END_SPAN);
             }
             if (c.getUpdatedDsts().contains(t)) {
-                int dId = mappingIds.get(t);
+                int dId = mappingIds.getInt(t);
                 rtags.addStartTag(t.getPos(), String.format(ID_SPAN, uId++));
                 rtags.addTags(t.getPos(), String.format(
                                 DST_MV_SPAN, "token upd", dId, tooltip(diff.dst, t)), t.getEndPos(), END_SPAN);

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -2,7 +2,7 @@ description = 'GumTree core module.'
 
 dependencies {
 	implementation 'com.github.mpkorstanje:simmetrics-core:3.2.3'
-	implementation 'net.sf.trove4j:trove4j:3.0.3'
+	implementation 'it.unimi.dsi:fastutil:8.3.1'
 	implementation 'com.google.code.gson:gson:2.8.2'
 	implementation 'org.jgrapht:jgrapht-core:1.0.1'
 }

--- a/core/src/main/java/com/github/gumtreediff/matchers/heuristic/gt/CliqueSubtreeMatcher.java
+++ b/core/src/main/java/com/github/gumtreediff/matchers/heuristic/gt/CliqueSubtreeMatcher.java
@@ -34,13 +34,13 @@ import com.github.gumtreediff.matchers.MultiMappingStore;
 import com.github.gumtreediff.tree.Tree;
 import com.github.gumtreediff.utils.Pair;
 
-import gnu.trove.map.hash.TIntObjectHashMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 
 public class CliqueSubtreeMatcher extends AbstractSubtreeMatcher {
 
     @Override
     public void filterMappings(MultiMappingStore multiMappings) {
-        TIntObjectHashMap<Pair<List<Tree>, List<Tree>>> cliques = new TIntObjectHashMap<>();
+        Int2ObjectOpenHashMap<Pair<List<Tree>, List<Tree>>> cliques = new Int2ObjectOpenHashMap<>();
         for (Mapping m : multiMappings) {
             int hash = m.first.getMetrics().hash;
             if (!cliques.containsKey(hash))
@@ -51,7 +51,7 @@ public class CliqueSubtreeMatcher extends AbstractSubtreeMatcher {
 
         List<Pair<List<Tree>, List<Tree>>> ccliques = new ArrayList<>();
 
-        for (int hash : cliques.keys()) {
+        for (int hash : cliques.keySet()) {
             Pair<List<Tree>, List<Tree>> clique = cliques.get(hash);
             if (clique.first.size() == 1 && clique.second.size() == 1) {
                 mappings.addMappingRecursively(clique.first.get(0), clique.second.get(0));


### PR DESCRIPTION
trove4j's last significant commit is from 2018, the last news on its website is from 2009, and the last release (3.1a1) was done in 2014. This PR replaces that dependency with the more up to date [fastutil](http://fastutil.di.unimi.it/).