### PR TITLE
Fix bug in edit script simplification

### DIFF
--- a/core/src/main/java/com/github/gumtreediff/actions/SimplifiedChawatheScriptGenerator.java
+++ b/core/src/main/java/com/github/gumtreediff/actions/SimplifiedChawatheScriptGenerator.java
@@ -51,7 +51,7 @@ public class SimplifiedChawatheScriptGenerator implements EditScriptGenerator {
 
 
         for (Tree t : addedTrees.keySet()) {
-            if (addedTrees.keySet().contains(t.getParent()) && addedTrees.keySet().containsAll(t.getDescendants()))
+            if (addedTrees.keySet().contains(t.getParent()) && addedTrees.keySet().containsAll(t.getParent().getDescendants()))
                 actions.remove(addedTrees.get(t));
             else {
                 if (t.getChildren().size() > 0 && addedTrees.keySet().containsAll(t.getDescendants())) {
@@ -66,7 +66,7 @@ public class SimplifiedChawatheScriptGenerator implements EditScriptGenerator {
         }
 
         for (Tree t : deletedTrees.keySet()) {
-            if (deletedTrees.keySet().contains(t.getParent()) && deletedTrees.keySet().containsAll(t.getDescendants()))
+            if (deletedTrees.keySet().contains(t.getParent()) && deletedTrees.keySet().containsAll(t.getParent().getDescendants()))
                 actions.remove(deletedTrees.get(t));
             else {
                 if (t.getChildren().size() > 0 && deletedTrees.keySet().containsAll(t.getDescendants())) {

--- a/core/src/main/java/com/github/gumtreediff/actions/SimplifiedChawatheScriptGenerator.java
+++ b/core/src/main/java/com/github/gumtreediff/actions/SimplifiedChawatheScriptGenerator.java
@@ -51,7 +51,8 @@ public class SimplifiedChawatheScriptGenerator implements EditScriptGenerator {
 
 
         for (Tree t : addedTrees.keySet()) {
-            if (addedTrees.keySet().contains(t.getParent()) && addedTrees.keySet().containsAll(t.getParent().getDescendants()))
+            if (addedTrees.keySet().contains(t.getParent())
+                    && addedTrees.keySet().containsAll(t.getParent().getDescendants()))
                 actions.remove(addedTrees.get(t));
             else {
                 if (t.getChildren().size() > 0 && addedTrees.keySet().containsAll(t.getDescendants())) {
@@ -66,7 +67,8 @@ public class SimplifiedChawatheScriptGenerator implements EditScriptGenerator {
         }
 
         for (Tree t : deletedTrees.keySet()) {
-            if (deletedTrees.keySet().contains(t.getParent()) && deletedTrees.keySet().containsAll(t.getParent().getDescendants()))
+            if (deletedTrees.keySet().contains(t.getParent())
+                    && deletedTrees.keySet().containsAll(t.getParent().getDescendants()))
                 actions.remove(deletedTrees.get(t));
             else {
                 if (t.getChildren().size() > 0 && deletedTrees.keySet().containsAll(t.getDescendants())) {


### PR DESCRIPTION
Consider the following tree:
![a](https://user-images.githubusercontent.com/446776/108397078-a6f0f680-7228-11eb-818e-fd39592f7cfd.png)
where vertices 1, 3, 4, 5 and 6 are added and vertex 2 is already existing (e. g. it's an existing statement moved into a new `if` or a loop).
When the simplification is processing vertex 3 (`t`), `t`'s parent is 1 and `t`'s descendants are 4, 5 and 6. Insertion of 3 gets removed, but insertion of 1 is not transformed into `InsertTree`, because vertex 2 is not added. So, the addition of vertex 3 is lost.
Example of code that demonstrates the issue:
old:
```c
void foo(int a) {
    bar();
}
```
new:
```c
void foo(int a) {
    if (a == 42) {
        bar();
    }
}
```

This pull request fixes the issue, so that an insertion is removed only if the addition of the parent node or one of its ancestors is transformed into `InsertTree`.
The same issue applies to `Delete` actions, if the diff is applied to the same code fragments in reverse order.