### PR TITLE
Diff class support for Resources

### DIFF
--- a/core/src/main/java/com/github/gumtreediff/actions/Diff.java
+++ b/core/src/main/java/com/github/gumtreediff/actions/Diff.java
@@ -14,7 +14,8 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with GumTree.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Copyright 2019 Jean-Rémy Falleri <jr.falleri@gmail.com>
+ * Copyright 2022 Jean-Rémy Falleri <jr.falleri@gmail.com>
+ * Copyright 2022 Raquel Pau <raquelpau@gmail.com>
  */
 
 package com.github.gumtreediff.actions;
@@ -27,6 +28,7 @@ import com.github.gumtreediff.matchers.Matchers;
 import com.github.gumtreediff.tree.TreeContext;
 
 import java.io.IOException;
+import java.io.Reader;
 
 /**
  * Class to facilitate the computation of diffs between ASTs.
@@ -78,11 +80,34 @@ public class Diff {
                                String matcher, GumtreeProperties properties) throws IOException {
         TreeContext src = TreeGenerators.getInstance().getTree(srcFile, treeGenerator);
         TreeContext dst = TreeGenerators.getInstance().getTree(dstFile, treeGenerator);
+
+        return compute(src, dst, treeGenerator, matcher, properties);
+    }
+
+    private static Diff compute(TreeContext src, TreeContext dst, String treeGenerator,
+                               String matcher, GumtreeProperties properties) throws IOException {
         Matcher m = Matchers.getInstance().getMatcherWithFallback(matcher);
         m.configure(properties);
         MappingStore mappings = m.match(src.getRoot(), dst.getRoot());
         EditScript editScript = new SimplifiedChawatheScriptGenerator().computeActions(mappings);
         return new Diff(src, dst, mappings, editScript);
+    }
+
+    /**
+     * Compute and return a diff.
+     * @param srcReader The reader to the source file.
+     * @param dstReader The reader to the destination file.
+     * @param treeGenerator The id of the tree generator to use.
+     * @param matcher The id of the the matcher to use.
+     * @param properties The set of options.
+     * @throws IOException an IO exception is raised in case of IO problems related to the source
+     *     or destination file.
+     */
+    public static Diff compute(Reader srcReader, Reader dstReader, String treeGenerator,
+                               String matcher, GumtreeProperties properties) throws IOException {
+        TreeContext src = TreeGenerators.getInstance().getTree(srcReader, treeGenerator);
+        TreeContext dst = TreeGenerators.getInstance().getTree(dstReader, treeGenerator);
+        return compute(src, dst, treeGenerator, matcher, properties);
     }
 
     /**

--- a/core/src/main/java/com/github/gumtreediff/gen/TreeGenerators.java
+++ b/core/src/main/java/com/github/gumtreediff/gen/TreeGenerators.java
@@ -76,6 +76,21 @@ public class TreeGenerators extends Registry<String, TreeGenerator, Register> {
         throw new UnsupportedOperationException("No generator \"" + generator + "\" found.");
     }
 
+    /**
+     * Search the tree generator with the provided name , and use it
+     * to produce a TreeContext containing the AST.
+     *
+     * @param generator the tree generator's name. It can't be null
+     * @throws UnsupportedOperationException if no suitable generator is found
+     */
+    public TreeContext getTree(Reader stream, String generator) throws UnsupportedOperationException, IOException {
+        for (Entry e : entries)
+            if (e.id.equals(generator))
+                return e.instantiate(null).generateFrom().reader(stream);
+
+        throw new UnsupportedOperationException("No generator \"" + generator + "\" found.");
+    }
+
     public TreeContext getTreeFromCommand(String file, String command) throws IOException {
         TreeGenerator g = new ExternalProcessTreeGenerator() {
             @Override

--- a/core/src/main/java/com/github/gumtreediff/matchers/Matchers.java
+++ b/core/src/main/java/com/github/gumtreediff/matchers/Matchers.java
@@ -93,6 +93,12 @@ public class Matchers extends Registry<String, Matcher, Register> {
         super.install(clazz, a);
     }
 
+    @Override
+    public void clear() {
+        super.clear();
+        defaultMatcherFactory = null;
+    }
+
     protected String getName(Register annotation, Class<? extends Matcher> clazz) {
         return annotation.id();
     }

--- a/core/src/main/java/com/github/gumtreediff/utils/Registry.java
+++ b/core/src/main/java/com/github/gumtreediff/utils/Registry.java
@@ -70,6 +70,10 @@ public abstract class Registry<K, C, A> {
         entries.add(entry);
     }
 
+    public void clear() {
+        entries.clear();
+    }
+
     protected abstract Entry newEntry(Class<? extends C> clazz, A annotation);
 
     protected Entry findEntry(K key) {

--- a/core/src/test/java/com/github/gumtreediff/test/TestDiff.java
+++ b/core/src/test/java/com/github/gumtreediff/test/TestDiff.java
@@ -1,0 +1,79 @@
+/*
+ * This file is part of GumTree.
+ *
+ * GumTree is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * GumTree is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with GumTree.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright 2011-2022 Jean-Rémy Falleri <jr.falleri@gmail.com>
+ * Copyright 2011-2022 Floréal Morandat <florealm@gmail.com>
+ * Copyright 2011-2022 Raquel Pau <raquelpau@gmail.com>
+ */
+package com.github.gumtreediff.test;
+
+import com.github.gumtreediff.actions.Diff;
+import com.github.gumtreediff.gen.Register;
+import com.github.gumtreediff.gen.TreeGenerators;
+import com.github.gumtreediff.io.TreeIoUtils;
+import com.github.gumtreediff.matchers.*;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.FileReader;
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TestDiff {
+
+    private static String TREE_GENERATOR_ID = "xml";
+    private static String MATCHER_ID = "gumtree-simple";
+    private static String PATH_DUMMY_FILE = "src/test/resources/Dummy_v0.xml";
+
+    @BeforeAll
+    public static void prepareMatcher() {
+        Matcher matcher = new CompositeMatchers.SimpleGumtree();
+        Matchers.getInstance().install(matcher.getClass(),
+                matcher.getClass().getAnnotation(com.github.gumtreediff.matchers.Register.class));
+    }
+
+    @BeforeAll
+    public static void prepareTreeGenerator() {
+        Register r = TreeIoUtils.XmlInternalGenerator.class.getAnnotation(Register.class);
+        TreeGenerators.getInstance().install(TreeIoUtils.XmlInternalGenerator.class, r);
+    }
+
+    @Test
+    public void testComputeWithReaders() throws IOException {
+        FileReader source = new FileReader(PATH_DUMMY_FILE);
+        FileReader target = new FileReader(PATH_DUMMY_FILE);
+
+        Diff resultWithReader = Diff.compute(source, target, TREE_GENERATOR_ID, MATCHER_ID,
+                new GumtreeProperties());
+
+        Diff resultWithFiles = Diff.compute(PATH_DUMMY_FILE, PATH_DUMMY_FILE, "xml",
+                "gumtree-simple",
+                new GumtreeProperties());
+
+        assertEquals(resultWithFiles.mappings.size(), resultWithReader.mappings.size());
+
+        assertNoChanges(resultWithReader.mappings);
+        assertNoChanges(resultWithFiles.mappings);
+
+    }
+
+   private static void assertNoChanges(MappingStore mappings) {
+       for (Mapping mapping: mappings){
+           assertEquals(mapping.first.toTreeString(), mapping.second.toTreeString());
+       }
+   }
+}

--- a/core/src/test/java/com/github/gumtreediff/test/TestDiff.java
+++ b/core/src/test/java/com/github/gumtreediff/test/TestDiff.java
@@ -71,9 +71,9 @@ public class TestDiff {
 
     }
 
-   private static void assertNoChanges(MappingStore mappings) {
-       for (Mapping mapping: mappings){
-           assertEquals(mapping.first.toTreeString(), mapping.second.toTreeString());
-       }
-   }
+    private static void assertNoChanges(MappingStore mappings) {
+        for (Mapping mapping : mappings) {
+            assertEquals(mapping.first.toTreeString(), mapping.second.toTreeString());
+        }
+    }
 }

--- a/core/src/test/java/com/github/gumtreediff/test/TestDiff.java
+++ b/core/src/test/java/com/github/gumtreediff/test/TestDiff.java
@@ -25,6 +25,7 @@ import com.github.gumtreediff.gen.Register;
 import com.github.gumtreediff.gen.TreeGenerators;
 import com.github.gumtreediff.io.TreeIoUtils;
 import com.github.gumtreediff.matchers.*;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -68,7 +69,12 @@ public class TestDiff {
 
         assertNoChanges(resultWithReader.mappings);
         assertNoChanges(resultWithFiles.mappings);
+    }
 
+    @AfterAll
+    public static void clear() {
+        Matchers.getInstance().clear();
+        TreeGenerators.getInstance().clear();
     }
 
     private static void assertNoChanges(MappingStore mappings) {


### PR DESCRIPTION
This commit is adding a new compute method to support the diff processing of resources instead of paths.

This functionality is intersting when the files that need to be computed are not in the local file and are downloaded from the Internet using APIs in memory.