### PR TITLE
Fix for type arguments of the generic functions in jdt

### DIFF
--- a/gen.jdt/src/main/java/com/github/gumtreediff/gen/jdt/JdtVisitor.java
+++ b/gen.jdt/src/main/java/com/github/gumtreediff/gen/jdt/JdtVisitor.java
@@ -62,6 +62,9 @@ public class JdtVisitor  extends AbstractJdtVisitor {
             push(i, METHOD_INVOCATION_RECEIVER, "", i.getExpression().getStartPosition(),
                     i.getExpression().getLength());
             i.getExpression().accept(this);
+            for (Object argument : i.typeArguments()) {
+                ((ASTNode) argument).accept(this);
+            }
             popNode();
         }
         pushNode(i.getName(), getLabel(i.getName()));

--- a/gen.jdt/src/test/java/com/github/gumtreediff/gen/jdt/TestJdtGenerator.java
+++ b/gen.jdt/src/test/java/com/github/gumtreediff/gen/jdt/TestJdtGenerator.java
@@ -165,4 +165,26 @@ public class TestJdtGenerator {
         assertEquals(ct.getRoot().getChild("0.3").getMetadata("id"), "Method foo( int String)");
         assertEquals(ct.getRoot().getChild("0.4").getMetadata("id"), "Method bar()");
     }
+
+    @Test
+    public void testGenericFunctionWithTypeParameter() throws IOException {
+        String input = "class testStructure { void foo() { Collections.<String>emptyList(); } }";
+        TreeContext ct = new JdtTreeGenerator().generateFrom().string(input);
+        String expected = "CompilationUnit [0,71]\n"
+                + "    TypeDeclaration [0,71]\n"
+                + "        TYPE_DECLARATION_KIND: class [0,5]\n"
+                + "        SimpleName: testStructure [6,19]\n"
+                + "        MethodDeclaration [22,69]\n"
+                + "            PrimitiveType: void [22,26]\n"
+                + "            SimpleName: foo [27,30]\n"
+                + "            Block [33,69]\n"
+                + "                ExpressionStatement [35,67]\n"
+                + "                    MethodInvocation [35,66]\n"
+                + "                        METHOD_INVOCATION_RECEIVER [35,46]\n"
+                + "                            SimpleName: Collections [35,46]\n"
+                + "                            SimpleType [48,54]\n"
+                + "                                SimpleName: String [48,54]\n"
+                + "                        SimpleName: emptyList [55,64]";
+        assertEquals(expected, ct.getRoot().toTreeString());
+    }
 }


### PR DESCRIPTION
This PR aims to fix issue https://github.com/GumTreeDiff/gumtree/issues/323.

TypeArguments of the method invocation are ignored after the introduction of MethodInvocationReceiver in 3.0 gen.jdt. 
Since java only allows to pass the type argument in case of having the receiver, I thought its better to have the reciver as the parent of the type arguments. In other words:

`<String> emptyList()`  &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; --> This runs into compilation error  ❌
`Collections.<String> emptyList()`&nbsp; -->   Works fine ✅ 

Also, typeArguments seem to be an empty list (not null) in case of having basic method invocations. So there is no need for additional null check.
I have also added a test to capture the newly added subtree.