### PR TITLE
Enable depandabot

### DIFF
--- a/.dependabot.yml
+++ b/.dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: gradle
+    directory: "/"
+    schedule:
+      interval: weekly
+    labels:
+      - "dependencies"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: weekly
+    labels:
+      - "dependencies"


### PR DESCRIPTION
This enabled [GitHub's depenadabot](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates) at this repository. It is for free and I personally like it.

It creates pull requests for version updates. Since there are CI checks in place, one can see if the version update causes a harm or not.