### PR TITLE
Fix for multithreaded execution

### DIFF
--- a/core/src/main/java/com/github/gumtreediff/tree/TypeSet.java
+++ b/core/src/main/java/com/github/gumtreediff/tree/TypeSet.java
@@ -35,7 +35,7 @@ public class TypeSet {
      * Build a type with the provided name. If the provided name is null or
      * the empty string, the empty type will be returned.
      */
-    public static Type type(String value) {
+    public static synchronized Type type(String value) {
         return implementation.makeOrGetType(value);
     }
 

--- a/core/src/test/java/com/github/gumtreediff/test/TestTree.java
+++ b/core/src/test/java/com/github/gumtreediff/test/TestTree.java
@@ -27,6 +27,9 @@ import java.util.List;
 import com.github.gumtreediff.tree.*;
 import org.junit.jupiter.api.Test;
 
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 public class TestTree {
@@ -284,5 +287,26 @@ public class TestTree {
         t3.setPos(1);
         t3.setLength(2);
         assertEquals("foo: hello [1,3]", t3.toString());
+    }
+
+    @Test
+    public void testTypeThreading() throws InterruptedException {
+        int n = 20;
+        ExecutorService exec = Executors.newFixedThreadPool(n);
+        List<Type> types = new ArrayList<>();
+
+        for (int i = 0; i < n; i++) {
+            exec.submit(() -> {
+                types.add(TypeSet.type("foo"));
+            });
+        }
+
+        exec.awaitTermination(1, java.util.concurrent.TimeUnit.SECONDS);
+
+        for (Type t1 : types) {
+            for (Type t2: types) {
+                assertSame(t1, t2);
+            }
+        }
     }
 }


### PR DESCRIPTION
Hello,

I've identified a bug affecting multithreaded execution.

This PR consists of 3 commits, and I'll break down each commit:

- I have created a repeated test (executes in separate threads) ([commit#1](https://github.com/GumTreeDiff/gumtree/commit/94a55c58b017467ddc1eee64f1ce081216157dff)) which runs GumTree _Classic_ matcher on a file revision, and observed discrepancies in the number of generated mappings. To enable a multithreaded environment, I relied on JUnit 5's CONCURRENT execution, requiring the addition of junit-platform.properties.
  <img src="https://github.com/GumTreeDiff/gumtree/assets/28820932/c3456220-c502-4f0f-ab7f-b7442a25fc22" width="400" alt="Flaky test"> 
*Test result in a multithreaded environment **before** the fix*

- After investigating, I realized the issue lies in the equality check for types `getType() == t.getType()`, which works in a single-threaded environment but fails when multiple GumTree instances are running. In [commit#2](https://github.com/GumTreeDiff/gumtree/commit/d79df4c24f45736ed83050e22db6fbceb29eb635), I addressed this problem for _Classic_ and _Simple_ Matchers (also _ZsMatcher_ since _Classic_ depends on that)<img src="https://github.com/GumTreeDiff/gumtree/assets/28820932/c31ad161-3125-41b5-a77b-f45d523806f3" width="400" alt="Stable Test">
*Test result in a multithreaded environment **after** the fix*

- Additionally, I noticed the same issue across different matchers, leading to [commit#3](https://github.com/GumTreeDiff/gumtree/commit/d2b19dbef0da8f5fa752e5b0b50339da63b8b025), where I replicated the fix throughout the entire project.

**P.S**: I'm aware that the test should ideally be located in the core module, but due to the dependency on JdtTreeGenerator, I couldn't move it. I can export the tree XML and load it to eliminate the dependency. Please let me know your thoughts.