### PR TITLE
Fix paths of files to read for webdiff

### DIFF
--- a/client.diff/src/main/java/com/github/gumtreediff/client/diff/webdiff/VanillaDiffView.java
+++ b/client.diff/src/main/java/com/github/gumtreediff/client/diff/webdiff/VanillaDiffView.java
@@ -103,8 +103,8 @@ public class VanillaDiffView {
                     style(readFile("web/dist/vanilla.css")).withType("text/css"),
                     script().withType("text/javascript").withSrc(WebDiff.JQUERY_JS_URL),
                     script().withType("text/javascript").withSrc(WebDiff.BOOTSTRAP_JS_URL),
-                    script(readFile("/dist/shortcuts.js")).withType("text/javascript"),
-                    script(readFile("/dist/vanilla.js")).withType("text/javascript")
+                    script(readFile("web/dist/shortcuts.js")).withType("text/javascript"),
+                    script(readFile("web/dist/vanilla.js")).withType("text/javascript")
                 );
             }
         }


### PR DESCRIPTION
This was most direct way to avoid the error below and seems consistent with the vanilla.css readFile instance.

```
./dist/build/install/gumtree/bin/gumtree htmldiff /tmp/lhs.mlir /tmp/rhs.mlir
Error while running client 'htmldiff'.
java.lang.NullPointerException
	at java.base/java.io.Reader.<init>(Reader.java:168)
	at java.base/java.io.InputStreamReader.<init>(InputStreamReader.java:112)
	at com.github.gumtreediff.client.diff.webdiff.VanillaDiffView$Header.readFile(VanillaDiffView.java:115)
	at com.github.gumtreediff.client.diff.webdiff.VanillaDiffView$Header.build(VanillaDiffView.java:106)
	at com.github.gumtreediff.client.diff.webdiff.VanillaDiffView.build(VanillaDiffView.java:42)
	at com.github.gumtreediff.client.diff.HtmlDiff.run(HtmlDiff.java:67)
	at com.github.gumtreediff.client.Run.startClient(Run.java:94)
	at com.github.gumtreediff.client.Run.main(Run.java:128)
```