### PR TITLE
fix: update deepCopy JavaDoc to specify that metadata is not copied.

### DIFF
--- a/core/src/main/java/com/github/gumtreediff/tree/Tree.java
+++ b/core/src/main/java/com/github/gumtreediff/tree/Tree.java
@@ -206,7 +206,7 @@ public interface Tree {
     }
 
     /**
-     * Make a deep copy of the tree. Deep copy of node however shares Metadata
+     * Make a deep copy of the tree. Metadata is not copied over.
      */
     Tree deepCopy();
 


### PR DESCRIPTION
fixes #361 