### PR TITLE
feat: optionalTagName for javadocs in jdt

### DIFF
--- a/gen.jdt/src/main/java/com/github/gumtreediff/gen/jdt/JdtVisitor.java
+++ b/gen.jdt/src/main/java/com/github/gumtreediff/gen/jdt/JdtVisitor.java
@@ -41,6 +41,7 @@ public class JdtVisitor  extends AbstractJdtVisitor {
     private static final Type ASSIGNMENT_OPERATOR = type("ASSIGNMENT_OPERATOR");
     private static final Type PREFIX_EXPRESSION_OPERATOR = type("PREFIX_EXPRESSION_OPERATOR");
     private static final Type POSTFIX_EXPRESSION_OPERATOR = type("POSTFIX_EXPRESSION_OPERATOR");
+    private static final Type TAG_NAME = type("TAG_NAME");
 
     private static final Type ARRAY_INITIALIZER = nodeAsSymbol(ASTNode.ARRAY_INITIALIZER);
     private static final Type SIMPLE_NAME = nodeAsSymbol(ASTNode.SIMPLE_NAME);
@@ -111,6 +112,10 @@ public class JdtVisitor  extends AbstractJdtVisitor {
 
     @Override
     public boolean visit(TagElement e) {
+        if (e.getTagName() != null && !e.getTagName().isEmpty()) {
+            push(e, TAG_NAME, e.getTagName(), e.getStartPosition(), e.getTagName().length());
+            popNode();
+        }
         return true;
     }
 

--- a/gen.jdt/src/test/java/com/github/gumtreediff/gen/jdt/TestJdtGenerator.java
+++ b/gen.jdt/src/test/java/com/github/gumtreediff/gen/jdt/TestJdtGenerator.java
@@ -187,4 +187,19 @@ public class TestJdtGenerator {
                 + "                        SimpleName: emptyList [55,64]";
         assertEquals(expected, ct.getRoot().toTreeString());
     }
+
+    @Test
+    public void testTagElement() throws IOException {
+        String input = "/** @author john */ class C {}";
+        TreeContext ct = new JdtTreeGenerator().generateFrom().string(input);
+        String expected = "CompilationUnit [0,30]\n"
+                + "    TypeDeclaration [0,30]\n"
+                + "        Javadoc [0,19]\n"
+                + "            TagElement [4,17]\n"
+                + "                TAG_NAME: @author [4,11]\n"
+                + "                TextElement:  john  [11,17]\n"
+                + "        TYPE_DECLARATION_KIND: class [20,25]\n"
+                + "        SimpleName: C [26,27]";
+        assertEquals(expected, ct.getRoot().toTreeString());
+    }
 }


### PR DESCRIPTION
This is the fix for https://github.com/GumTreeDiff/gumtree/issues/355

```@author john */ class C {}``` now will be represented as:

```
CompilationUnit [0,30]
                TypeDeclaration [0,30]
                    Javadoc [0,19]
                        TagElement [4,17]
                            TAG_NAME: @author [4,11]
                            TextElement:  john  [11,17]
                    TYPE_DECLARATION_KIND: class [20,25]
                    SimpleName: C [26,27]
```