### PR TITLE
fix: visit non-attached java-docs (comments) same as the rest of the …

### DIFF
--- a/gen.jdt/src/main/java/com/github/gumtreediff/gen/jdt/JdtWithCommentsVisitor.java
+++ b/gen.jdt/src/main/java/com/github/gumtreediff/gen/jdt/JdtWithCommentsVisitor.java
@@ -52,11 +52,11 @@ public class JdtWithCommentsVisitor extends JdtVisitor {
         }
 
         public boolean visit(Javadoc node) {
-            //We have to check if the java doc is attached to any program element or not
+            //We have to check if the Javadoc is attached to any program element or not
             //The attached ones, have been already visited, and we do not want to add them twice.
             if (node.getParent() == null)
-                //Then it is javadoc which is attached to any program element,
-                //So it will be visited as same as the other comments but with JavaDoc label
+                //Then it is Javadoc attached to any program element,
+                //So we do as the same as the other Javadocs in the original visitors
                 return visitComment(node);
             return true;
         }
@@ -65,6 +65,15 @@ public class JdtWithCommentsVisitor extends JdtVisitor {
             int start = node.getStartPosition();
             int end = start + node.getLength();
             Tree parent = findMostInnerEnclosingParent(context.getRoot(), start, end);
+            if (node instanceof Javadoc) {
+                trees.push(parent);
+                node.accept(JdtWithCommentsVisitor.this);
+                Tree wrongOrderChild = parent.getChild(parent.getChildren().size() - 1);
+                parent.getChildren().remove(wrongOrderChild);
+                insertChildProperly(parent, wrongOrderChild);
+                trees.pop();
+                return true;
+            }
             Tree t = context.createTree(nodeAsSymbol(node), new String(scanner.getSource(), start, end - start));
             t.setPos(start);
             t.setLength(node.getLength());

--- a/gen.jdt/src/test/java/com/github/gumtreediff/gen/jdt/TestJdtGenerator.java
+++ b/gen.jdt/src/test/java/com/github/gumtreediff/gen/jdt/TestJdtGenerator.java
@@ -254,9 +254,9 @@ public class TestJdtGenerator {
                 + "                PrimitiveType: boolean [60,67]\n"
                 + "                SimpleName: b [68,69]\n"
                 + "            Block [76,142]\n"
-                + "                Javadoc: /**\n"
-                + "         * test2 \n"
-                + "         */ [86,119]\n"
+                + "                Javadoc [86,119]\n"
+                + "                    TagElement [101,107]\n"
+                + "                        TextElement: test2  [101,107]\n"
                 + "                ExpressionStatement [128,136]\n"
                 + "                    MethodInvocation [128,135]\n"
                 + "                        SimpleName: sleep [128,133]";


### PR DESCRIPTION
Hello, 
This is a continuation of https://github.com/GumTreeDiff/gumtree/pull/368.
We discovered some edge cases (e.g., Closure 148 from the Defects4J dataset) that involve unusual code evolution. For instance:
![image](https://github.com/user-attachments/assets/c9c7b701-67ef-40f1-969c-884597708022)

In this example, the JavaDocs on the left-hand side are not associated with any program element. However, in the right-hand side, they are now attached to a program element.

Previously, we treated unattached JavaDocs as regular comments. This approach caused us to lose valuable information provided by the parser, such as their internal structure (e.g., tag elements).

To address this, we decided to handle unattached JavaDocs the same way we handle other JavaDocs, processing all the internal nodes during tree generation.

P.S.: The screenshot was taken after applying the PR, which is why the subtrees are matched correctly.
