### PR TITLE
Fix LeafMoveMatcherThetaE

### DIFF
--- a/core/src/main/java/com/github/gumtreediff/matchers/optimizations/LeafMoveMatcherThetaE.java
+++ b/core/src/main/java/com/github/gumtreediff/matchers/optimizations/LeafMoveMatcherThetaE.java
@@ -194,6 +194,12 @@ public class LeafMoveMatcherThetaE implements Matcher {
                 for (Tree child : firstParent.getChildren()) {
                     if (child.isLeaf() && !mappings.isDstMapped(child) && child.getType() == pair.second.getType()
                             && child.getLabel().equals(pair.second.getLabel())) {
+                        Tree dstForSrc = mappings.getDstForSrc(child);
+                        if (dstForSrc != null)
+                            mappings.removeMapping(child, dstForSrc);
+                        Tree srcForDst = mappings.getSrcForDst(pair.second);
+                        if (srcForDst != null)
+                            mappings.removeMapping(srcForDst, pair.second);
                         mappings.addMapping(child, pair.second);
                         break;
                     }


### PR DESCRIPTION
This PR fixes a bug in the `ThetaE` optimization logic where adding a new mapping could leave `srcToDst` and `dstToSrc` inconsistent.

In certain cases, a new mapping is added without first removing existing conflicting entries. This can cause one of the maps to still hold the old mapping, leading to lost mappings in the final result.

Example commit demonstrating the issue:
https://github.com/pouryafard75/TestCases/commit/fb4498be010c788a40c108ce6592b29a205634da

**Before optimization:**
<img width="1092" height="541" alt="Before optimization" src="https://github.com/user-attachments/assets/af37a26b-c0e5-453c-b83a-1681b7c10b17" />

**After optimization:**
<img width="1087" height="533" alt="After optimization" src="https://github.com/user-attachments/assets/64e3130c-f27d-4f75-92b0-d9fd2fd6ade7" />

**My proposed fix:**
Before adding a new mapping, clear any existing entries in both `srcToDst` and `dstToSrc` that conflict with it. This ensures the maps remain consistent.

