### PR TITLE
feat: support drag-and-drop pairing of renamed files in webdiff

### DIFF
--- a/client.diff/src/main/java/com/github/gumtreediff/client/diff/webdiff/DirectoryDiffView.java
+++ b/client.diff/src/main/java/com/github/gumtreediff/client/diff/webdiff/DirectoryDiffView.java
@@ -64,7 +64,8 @@ public class DirectoryDiffView {
                                                 span("" + comparator.getDeletedFiles().size()).withClasses("badge", "badge-secondary"))
                                     ).withClasses("card-title", "mb-0")
                                 ).withClasses("card-header", "bg-danger"),
-                                iff(comparator.getDeletedFiles().size() > 0, AddedOrDeletedFiles.build(comparator.getDeletedFiles(), comparator.getSrc()))
+                                iff(comparator.getDeletedFiles().size() > 0,
+                                        DeletedFiles.build(comparator.getDeletedFiles(), comparator.getSrc()))
                             ).withClass("card")
                         ).withClass("col"),
                         div(
@@ -75,7 +76,8 @@ public class DirectoryDiffView {
                                                 span("" + comparator.getAddedFiles().size()).withClasses("badge", "badge-secondary"))
                                     ).withClasses("card-title", "mb-0")
                                 ).withClasses("card-header", "bg-success"),
-                                    iff(comparator.getAddedFiles().size() > 0, AddedOrDeletedFiles.build(comparator.getAddedFiles(), comparator.getSrc()))
+                                    iff(comparator.getAddedFiles().size() > 0,
+                                            AddedFiles.build(comparator.getAddedFiles(), comparator.getDst()))
                             ).withClass("card")
                         ).withClass("col")
                     ).withClasses("row", "mb-3")
@@ -88,34 +90,75 @@ public class DirectoryDiffView {
         public static Tag build(List<Pair<File, File>> files, DirectoryComparator comparator) {
             return table(
                 tbody(
-                    each(files, (id, file) -> tr(
-                        td(comparator.getSrc().toAbsolutePath().relativize(file.first.toPath().toAbsolutePath()).toString()),
-                        td(
-                            div(
+                    each(files, (id, file) -> {
+                        String srcRelPath = comparator.getSrc().toAbsolutePath()
+                                .relativize(file.first.toPath().toAbsolutePath()).toString();
+                        String dstRelPath = comparator.getDst().toAbsolutePath()
+                                .relativize(file.second.toPath().toAbsolutePath()).toString();
+                        boolean isRenamed = !srcRelPath.equals(dstRelPath);
+                        return tr(
+                            td(
+                                isRenamed
+                                    ? join(text(srcRelPath), rawHtml(" &rarr; "), text(dstRelPath))
+                                    : text(srcRelPath)
+                            ),
+                            td(
                                 div(
-                                    iff(TreeGenerators.getInstance().hasGeneratorForFile(file.first.getAbsolutePath()), join(
-                                            a("monaco").withHref("/monaco-diff/" + id).withClasses("btn", "btn-primary", "btn-sm"),
-                                            a("classic").withHref("/vanilla-diff/" + id).withClasses("btn", "btn-primary", "btn-sm")
-                                        )
-                                    ),
-                                    a("monaco-native").withHref("/monaco-native-diff/" + id).withClasses("btn", "btn-primary", "btn-sm"),
-                                    a("mergely").withHref("/mergely-diff/" + id).withClasses("btn", "btn-primary", "btn-sm"),
-                                    a("raw").withHref("/raw-diff/" + id).withClasses("btn", "btn-primary", "btn-sm")
-                                ).withClass("btn-group")
-                            ).withClasses("btn-toolbar", "justify-content-end")
-                        )
-                    ))
+                                    div(
+                                        iff(TreeGenerators.getInstance().hasGeneratorForFile(file.first.getAbsolutePath()), join(
+                                                a("monaco").withHref("/monaco-diff/" + id).withClasses("btn", "btn-primary", "btn-sm"),
+                                                a("classic").withHref("/vanilla-diff/" + id).withClasses("btn", "btn-primary", "btn-sm")
+                                            )
+                                        ),
+                                        a("monaco-native").withHref("/monaco-native-diff/" + id).withClasses("btn", "btn-primary", "btn-sm"),
+                                        a("mergely").withHref("/mergely-diff/" + id).withClasses("btn", "btn-primary", "btn-sm"),
+                                        a("raw").withHref("/raw-diff/" + id).withClasses("btn", "btn-primary", "btn-sm"),
+                                        iff(isRenamed,
+                                            button("unpair").withClasses("btn", "btn-warning", "btn-sm", "ms-2")
+                                                    .attr("onclick", "unpairFiles(" + id + ")"))
+                                    ).withClass("btn-group")
+                                ).withClasses("btn-toolbar", "justify-content-end")
+                            )
+                        );
+                    })
                 )
             ).withClasses("table", "card-table", "table-striped", "table-condensed", "mb-0");
         }
     }
 
-    private static class AddedOrDeletedFiles  {
+    private static class DeletedFiles {
 
         public static Tag build(Set<File> files, Path root) {
             return table(
                 tbody(
-                    each(files, file -> tr(td(root.relativize(file.toPath()).toString())))
+                    each(files, file -> {
+                        String relPath = root.relativize(file.toPath()).toString();
+                        return tr(
+                            td(relPath)
+                        ).attr("draggable", "true")
+                         .attr("data-path", relPath)
+                         .attr("data-side", "deleted")
+                         .withClass("draggable-file");
+                    })
+                )
+            ).withClasses("table", "card-table", "table-striped", "table-condensed", "mb-0");
+        }
+    }
+
+    private static class AddedFiles {
+
+        public static Tag build(Set<File> files, Path root) {
+            return table(
+                tbody(
+                    each(files, file -> {
+                        String relPath = root.relativize(file.toPath()).toString();
+                        return tr(
+                            td(relPath)
+                        ).attr("draggable", "true")
+                         .attr("data-path", relPath)
+                         .attr("data-side", "added")
+                         .withClass("draggable-file");
+                    })
                 )
             ).withClasses("table", "card-table", "table-striped", "table-condensed", "mb-0");
         }
@@ -130,7 +173,12 @@ public class DirectoryDiffView {
                 title("GumTree"),
                 link().withRel("stylesheet").withType("text/css").withHref(WebDiff.BOOTSTRAP_CSS_URL),
                 script().withType("text/javascript").withSrc(WebDiff.BOOTSTRAP_JS_URL),
-                script().withType("text/javascript").withSrc("/dist/shortcuts.js")
+                script().withType("text/javascript").withSrc("/dist/shortcuts.js"),
+                script().withType("text/javascript").withSrc("/dist/dragdrop.js").attr("defer", "defer"),
+                rawHtml("<style>"
+                        + "tr.draggable-file { transition: background-color 0.15s; }"
+                        + "tr.drag-over { background-color: #ffc107 !important; }"
+                        + "</style>")
             );
         }
     }

--- a/client.diff/src/main/java/com/github/gumtreediff/client/diff/webdiff/WebDiff.java
+++ b/client.diff/src/main/java/com/github/gumtreediff/client/diff/webdiff/WebDiff.java
@@ -133,6 +133,21 @@ public class WebDiff extends AbstractDiffClient<WebDiff.WebDiffOptions> {
             Pair<File, File> pair = comparator.getModifiedFiles().get(id);
             return readFile(pair.second.getAbsolutePath(), Charset.defaultCharset());
         });
+        post("/pair-files", (request, response) -> {
+            String srcPath = request.queryParams("src");
+            String dstPath = request.queryParams("dst");
+            File srcFile = new File(comparator.getSrc().toFile(), srcPath);
+            File dstFile = new File(comparator.getDst().toFile(), dstPath);
+            comparator.pairFiles(srcFile, dstFile);
+            response.redirect("/list");
+            return "";
+        });
+        post("/unpair-files", (request, response) -> {
+            int id = Integer.parseInt(request.queryParams("id"));
+            comparator.unpairFiles(id);
+            response.redirect("/list");
+            return "";
+        });
         get("/quit", (request, response) -> {
             System.exit(0);
             return "";

--- a/client.diff/src/main/resources/web/dist/dragdrop.js
+++ b/client.diff/src/main/resources/web/dist/dragdrop.js
@@ -1,0 +1,81 @@
+document.addEventListener("DOMContentLoaded", function () {
+    var dragSource = null;
+    var rows = document.querySelectorAll("tr.draggable-file");
+
+    rows.forEach(function (row) {
+        row.style.cursor = "grab";
+
+        row.addEventListener("dragstart", function (e) {
+            dragSource = {
+                path: row.getAttribute("data-path"),
+                side: row.getAttribute("data-side")
+            };
+            e.dataTransfer.effectAllowed = "move";
+            e.dataTransfer.setData("text/plain", "");
+            row.style.opacity = "0.5";
+        });
+
+        row.addEventListener("dragend", function () {
+            dragSource = null;
+            row.style.opacity = "";
+            document.querySelectorAll("tr.drag-over").forEach(function (el) {
+                el.classList.remove("drag-over");
+            });
+        });
+
+        row.addEventListener("dragover", function (e) {
+            if (!dragSource || dragSource.side === row.getAttribute("data-side")) return;
+            e.preventDefault();
+            e.dataTransfer.dropEffect = "move";
+        });
+
+        row.addEventListener("dragenter", function (e) {
+            if (!dragSource || dragSource.side === row.getAttribute("data-side")) return;
+            e.preventDefault();
+            row.classList.add("drag-over");
+        });
+
+        row.addEventListener("dragleave", function (e) {
+            if (e.relatedTarget && row.contains(e.relatedTarget)) return;
+            row.classList.remove("drag-over");
+        });
+
+        row.addEventListener("drop", function (e) {
+            e.preventDefault();
+            e.stopPropagation();
+            row.classList.remove("drag-over");
+
+            if (!dragSource) return;
+
+            var dropSide = row.getAttribute("data-side");
+            var dropPath = row.getAttribute("data-path");
+
+            if (dragSource.side === dropSide) return;
+
+            var srcPath, dstPath;
+            if (dragSource.side === "deleted") {
+                srcPath = dragSource.path;
+                dstPath = dropPath;
+            } else {
+                srcPath = dropPath;
+                dstPath = dragSource.path;
+            }
+
+            dragSource = null;
+
+            var form = document.createElement("form");
+            form.method = "POST";
+            form.action = "/pair-files?src=" + encodeURIComponent(srcPath) + "&dst=" + encodeURIComponent(dstPath);
+            document.body.appendChild(form);
+            form.submit();
+        });
+    });
+});
+
+function unpairFiles(id) {
+    var form = document.createElement("form");
+    form.method = "POST";
+    form.action = "/unpair-files?id=" + id;
+    document.body.appendChild(form);
+    form.submit();
+}

--- a/core/src/main/java/com/github/gumtreediff/io/DirectoryComparator.java
+++ b/core/src/main/java/com/github/gumtreediff/io/DirectoryComparator.java
@@ -128,6 +128,22 @@ public class DirectoryComparator {
         return addedFiles;
     }
 
+    public void pairFiles(File srcFile, File dstFile) {
+        if (!deletedFiles.remove(srcFile))
+            throw new IllegalArgumentException("File " + srcFile + " is not in the deleted files set.");
+        if (!addedFiles.remove(dstFile))
+            throw new IllegalArgumentException("File " + dstFile + " is not in the added files set.");
+        modifiedFiles.add(new Pair<>(srcFile, dstFile));
+    }
+
+    public void unpairFiles(int id) {
+        if (id < 0 || id >= modifiedFiles.size())
+            throw new IllegalArgumentException("Invalid pair id: " + id);
+        Pair<File, File> pair = modifiedFiles.remove(id);
+        deletedFiles.add(pair.first);
+        addedFiles.add(pair.second);
+    }
+
     private File toSrcFile(String s) {
         return new File(src.toFile(), s);
     }

--- a/core/src/test/java/com/github/gumtreediff/test/TestDirectoryComparator.java
+++ b/core/src/test/java/com/github/gumtreediff/test/TestDirectoryComparator.java
@@ -22,6 +22,8 @@ package com.github.gumtreediff.test;
 import com.github.gumtreediff.io.DirectoryComparator;
 import org.junit.jupiter.api.Test;
 
+import java.io.File;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 public class TestDirectoryComparator {
@@ -69,5 +71,51 @@ public class TestDirectoryComparator {
             DirectoryComparator cmp = new DirectoryComparator("src/test/resources/action_v0.xml",
                     "src/test/resources");
         });
+    }
+
+    @Test
+    public void testPairAndUnpairFiles() {
+        DirectoryComparator cmp = new DirectoryComparator("src/test/resources/diff/left",
+                "src/test/resources/diff/right");
+        cmp.compare();
+        assertEquals(1, cmp.getModifiedFiles().size());
+        assertEquals(2, cmp.getDeletedFiles().size());
+        assertEquals(2, cmp.getAddedFiles().size());
+
+        File srcFile = cmp.getDeletedFiles().stream()
+                .filter(f -> f.getName().equals("renamedLeft")).findFirst().get();
+        File dstFile = cmp.getAddedFiles().stream()
+                .filter(f -> f.getName().equals("renamedRight")).findFirst().get();
+
+        cmp.pairFiles(srcFile, dstFile);
+        assertEquals(2, cmp.getModifiedFiles().size());
+        assertEquals(1, cmp.getDeletedFiles().size());
+        assertEquals(1, cmp.getAddedFiles().size());
+        assertEquals("renamedLeft", cmp.getModifiedFiles().get(1).first.getName());
+        assertEquals("renamedRight", cmp.getModifiedFiles().get(1).second.getName());
+
+        cmp.unpairFiles(1);
+        assertEquals(1, cmp.getModifiedFiles().size());
+        assertEquals(2, cmp.getDeletedFiles().size());
+        assertEquals(2, cmp.getAddedFiles().size());
+    }
+
+    @Test
+    public void testPairFilesInvalidArguments() {
+        DirectoryComparator cmp = new DirectoryComparator("src/test/resources/diff/left",
+                "src/test/resources/diff/right");
+        cmp.compare();
+
+        File validDeleted = cmp.getDeletedFiles().iterator().next();
+        File validAdded = cmp.getAddedFiles().iterator().next();
+
+        assertThrows(IllegalArgumentException.class, () ->
+                cmp.pairFiles(new File("nonexistent"), validAdded));
+        assertThrows(IllegalArgumentException.class, () ->
+                cmp.pairFiles(validDeleted, new File("nonexistent")));
+        assertThrows(IllegalArgumentException.class, () ->
+                cmp.unpairFiles(-1));
+        assertThrows(IllegalArgumentException.class, () ->
+                cmp.unpairFiles(999));
     }
 }


### PR DESCRIPTION
Implements #335.

When comparing directories, renamed files appear as separate "deleted" and "added" entries with no way to compare them. This PR adds drag-and-drop support in the webdiff directory list view so users can manually pair renamed files for comparison.

## Before

Renamed files (`OldName.java` -> `NewName.java`) show up as unrelated deleted/added entries:

<img width="960" height="534" alt="01-before" src="https://github.com/user-attachments/assets/df96a24a-dc75-49b7-8559-8496c0f235fe" />

## After

Drag a file from the Deleted section onto a file in the Added section (or vice versa) to pair them. Paired files appear in the Modified section as `OldName.java -> NewName.java` with all diff viewers available, plus an "unpair" button to reverse the operation:

<img width="960" height="534" alt="02-after-pair" src="https://github.com/user-attachments/assets/cfc51997-fcc8-4527-b2c7-2987bc7e5864" />

Clicking any diff viewer on the paired entry works as expected:

<img width="960" height="534" alt="03-diff-view" src="https://github.com/user-attachments/assets/f10b9f38-880c-4b9a-801b-807d03c02452" />

## Changes

- **`DirectoryComparator`** - Added `pairFiles()` and `unpairFiles()` methods
- **`WebDiff`** - Added `POST /pair-files` and `POST /unpair-files` endpoints
- **`DirectoryDiffView`** - Drag-and-drop attributes on deleted/added rows, rename display (`old → new`), unpair button; also fixed added files being relativized against the wrong root directory
- **`dragdrop.js`** (new) - Client-side HTML5 drag-and-drop handling
- **`TestDirectoryComparator`** - Added tests for pair/unpair logic and invalid argument handling
